### PR TITLE
Allow native touch scrolling when drag handle is specified

### DIFF
--- a/crates/dnd/src/patterns/sortable/item.rs
+++ b/crates/dnd/src/patterns/sortable/item.rs
@@ -648,8 +648,12 @@ pub fn SortableItem(props: SortableItemProps) -> Element {
     };
 
     // Append functional drag styles to displacement style
-    let full_style =
-        format!("{displacement_style}; touch-action: none; user-select: none; cursor: grab;");
+    let has_handle = props.handle.is_some();
+    let full_style = if has_handle {
+        format!("{displacement_style}; touch-action: auto; user-select: none;")
+    } else {
+        format!("{displacement_style}; touch-action: none; user-select: none; cursor: grab;")
+    };
     let instructions_id = ctx.instructions_id();
 
     rsx! {
@@ -676,6 +680,7 @@ pub fn SortableItem(props: SortableItemProps) -> Element {
             "data-drop-adjacent": "{dnd_adjacent}",
             "data-displacement-mode": "{dnd_mode}",
             "data-keyboard-drag": if is_keyboard_dragging { "true" },
+            "data-dnd-handle-mode": if has_handle { "true" },
             // Pointer handlers (inlined from Draggable)
             onpointerdown: start_drag,
             onkeydown: onkeydown,

--- a/crates/dnd/src/primitives/draggable.rs
+++ b/crates/dnd/src/primitives/draggable.rs
@@ -428,7 +428,12 @@ pub fn Draggable(props: DraggableProps) -> Element {
     let merged_class = consumer_class.unwrap_or_default();
 
     // Library styles are FUNCTIONAL and REQUIRED for drag behavior
-    let library_style = "touch-action: none; user-select: none; cursor: grab;";
+    let has_handle = props.handle.is_some();
+    let library_style = if has_handle {
+        "touch-action: auto; user-select: none;"
+    } else {
+        "touch-action: none; user-select: none; cursor: grab;"
+    };
     let merged_style = merge_styles(library_style, consumer_style.as_deref());
 
     // Filter out class/style from attributes (already handled above)
@@ -526,6 +531,7 @@ pub fn Draggable(props: DraggableProps) -> Element {
             aria_grabbed: "{aria_grabbed}",
 
             "data-dnd-draggable": "",
+            "data-dnd-handle-mode": if has_handle { "true" },
             "data-state": "{dnd_state}",
             "data-disabled": "{dnd_disabled}",
 
@@ -746,5 +752,15 @@ mod tests {
         assert!(merged.contains("user-select: none"));
         assert!(merged.contains("cursor: grab"));
         assert!(merged.contains("background: red"));
+    }
+
+    #[test]
+    fn test_draggable_handle_mode_style_allows_touch_scroll() {
+        // When a handle is specified, touch-action should be auto to allow scrolling
+        let library_style = "touch-action: auto; user-select: none;";
+        let merged = merge_styles(library_style, Some("background: red;"));
+        assert!(merged.contains("touch-action: auto"));
+        assert!(merged.contains("user-select: none"));
+        assert!(!merged.contains("cursor: grab"));
     }
 }

--- a/crates/dnd/src/styles-functional.css
+++ b/crates/dnd/src/styles-functional.css
@@ -29,6 +29,12 @@
     -webkit-touch-callout: none;
 }
 
+/* When a drag handle is specified, allow native touch scrolling on the item body.
+   Only the handle element itself should have touch-action: none. */
+[data-dnd-draggable][data-dnd-handle-mode] {
+    touch-action: auto;
+}
+
 [data-dnd-draggable][data-state="dragging"] {
     opacity: 0;
     /* Default to hidden for cleaner sortable UX, overrides below if needed */
@@ -77,6 +83,12 @@
     -webkit-user-select: none;
     /* Crucial for touch dragging */
     touch-action: none;
+}
+
+/* When a drag handle is specified, allow native touch scrolling on sortable items.
+   Only the handle element itself should block touch gestures. */
+[data-dnd-item][data-dnd-handle-mode] {
+    touch-action: auto;
 }
 
 /* Hide user content while dragging (the "Ghost") — indicators/previews stay visible */


### PR DESCRIPTION
When a drag handle is present, set touch-action: auto on the draggable/sortable
item body so mobile users can scroll normally. Only the handle element itself
should block touch gestures. Adds data-dnd-handle-mode attribute and
corresponding CSS overrides.

https://claude.ai/code/session_011j4z1gXkmQaJVwPtF8TCQD