### PR TITLE
Add CI/CD workflow with fmt, clippy, test, and WASM build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace -- -D warnings
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  wasm-build:
+    name: WASM Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace --target wasm32-unknown-unknown

--- a/ARCHITECTURE-REVIEW.md
+++ b/ARCHITECTURE-REVIEW.md
@@ -70,7 +70,7 @@ This makes the demo — which serves as the primary showcase for 6+ library crat
 
 ---
 
-### [PRIORITY: High]
+### [PRIORITY: High] ✅ IMPLEMENTED
 **Area:** Developer Experience — No CI/CD
 **Problem:** No GitHub Actions, no CI configuration of any kind. The project has 492+ tests across 6 crates but no automated way to verify they pass on PRs. No clippy, no rustfmt enforcement, no WASM build validation.
 
@@ -80,6 +80,8 @@ This makes the demo — which serves as the primary showcase for 6+ library crat
 - `cargo test` (native target for unit tests)
 - `cargo build --target wasm32-unknown-unknown` for WASM compilation check
 - Matrix across stable + nightly Rust
+
+**Resolution:** Implemented in `.github/workflows/ci.yml` with four jobs: `fmt` (rustfmt check), `clippy` (workspace-wide lint with `-D warnings`), `test` (workspace tests), and `wasm-build` (WASM compilation verification). Runs on push/PR to main using stable Rust with dependency caching via `Swatinem/rust-cache`.
 
 **Expected Impact:** Catches regressions automatically; enforces code quality standards; builds confidence for contributors.
 


### PR DESCRIPTION
Implements the highest-leverage finding from ARCHITECTURE-REVIEW.md:
GitHub Actions CI with four jobs (rustfmt, clippy, workspace tests,
WASM build verification) triggered on push/PR to main.

https://claude.ai/code/session_0129pY14pErcJzCc1Bs165U1