### PR TITLE
fix: correct crate name in virtualize doc test

### DIFF
--- a/crates/virtualize/src/lib.rs
+++ b/crates/virtualize/src/lib.rs
@@ -1,4 +1,4 @@
-//! # dioxus-virtual
+//! # dioxus-nox-virtualize
 //!
 //! Viewport math for virtual scrolling lists with fixed-height items.
 //!
@@ -8,7 +8,7 @@
 //! ## Usage
 //!
 //! ```rust
-//! use dioxus_virtual::VirtualViewport;
+//! use dioxus_nox_virtualize::VirtualViewport;
 //!
 //! let mut vp = VirtualViewport::new(1000, 40, 400);
 //! vp.scroll_top = 800;


### PR DESCRIPTION
The doc test referenced `dioxus_virtual` instead of `dioxus_nox_virtualize`,
causing the CI Tests job to fail with exit code 101.

https://claude.ai/code/session_01VafAJazxTcUEieL3qqfTAn