### PR TITLE
feat(markdown): add HTML sanitization support and XSS security docs

### DIFF
--- a/ARCHITECTURE-REVIEW.md
+++ b/ARCHITECTURE-REVIEW.md
@@ -27,7 +27,7 @@ These crates are published in the workspace and importable but contain zero func
 
 ---
 
-### [PRIORITY: High]
+### [IMPLEMENTED] ~~[PRIORITY: High]~~
 **Area:** Security — `dangerous_inner_html` with User Content
 **Problem:** The markdown crate uses `dangerous_inner_html` in three locations (`crates/markdown/src/parser.rs:330,423,442` and `crates/markdown/src/viewport.rs:163`). While code highlighting output from syntect is generated server-side and is relatively safe, the raw HTML rendering path at `parser.rs:330` is gated only by `HtmlRenderPolicy::Trusted`:
 
@@ -70,7 +70,7 @@ This makes the demo — which serves as the primary showcase for 6+ library crat
 
 ---
 
-### [PRIORITY: High]
+### [IMPLEMENTED] ~~[PRIORITY: High]~~
 **Area:** Developer Experience — No CI/CD
 **Problem:** No GitHub Actions, no CI configuration of any kind. The project has 492+ tests across 6 crates but no automated way to verify they pass on PRs. No clippy, no rustfmt enforcement, no WASM build validation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ammonia"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+dependencies = [
+ "cssparser 0.35.0",
+ "html5ever 0.35.0",
+ "maplit",
+ "tendril",
+ "url",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +712,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1292,7 @@ dependencies = [
 name = "dioxus-nox-markdown"
 version = "0.1.0"
 dependencies = [
+ "ammonia",
  "crop",
  "dioxus",
  "dioxus-ssr",
@@ -2285,8 +2312,19 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
- "match_token",
+ "markup5ever 0.14.1",
+ "match_token 0.1.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever 0.35.0",
+ "match_token 0.35.0",
 ]
 
 [[package]]
@@ -2633,8 +2671,8 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap",
  "selectors",
 ]
@@ -2860,6 +2898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,10 +2918,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3399,7 +3465,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
@@ -3410,6 +3476,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3475,6 +3542,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4184,7 +4264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
+ "cssparser 0.29.6",
  "derive_more 0.99.20",
  "fxhash",
  "log",
@@ -5443,6 +5523,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6061,7 +6153,7 @@ dependencies = [
  "dpi",
  "dunce",
  "gtk",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "javascriptcore-rs",
  "jni",

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -14,6 +14,7 @@ gloo-timers = { workspace = true }
 crop = "0.4.3"
 pulldown-cmark = "0.13.1"
 syntect = { workspace = true, features = ["default-fancy", "html"], optional = true }
+ammonia = { version = "4", optional = true }
 
 [features]
 default = ["web"]
@@ -21,6 +22,7 @@ web = ["dioxus/web"]
 desktop = ["dioxus/desktop"]
 mobile = ["dioxus/mobile"]
 syntax-highlighting = ["dep:syntect"]
+sanitize = ["dep:ammonia"]
 
 [[example]]
 name = "basic_editor"

--- a/crates/markdown/src/components.rs
+++ b/crates/markdown/src/components.rs
@@ -133,10 +133,11 @@ pub fn Root(
     /// `Inline` = Obsidian-style cursor-aware single-surface editing.
     #[props(default)]
     live_preview_variant: LivePreviewVariant,
-    /// Controls raw HTML rendering behavior.
+    /// Controls raw HTML rendering behavior. See [`HtmlRenderPolicy`] for details.
     ///
-    /// Default is `Escape`, which renders HTML as text. Use `Trusted` only
-    /// for trusted markdown input.
+    /// - `Escape` (default): renders HTML tags as visible text. Safe for all inputs.
+    /// - `Sanitized`: strips dangerous HTML while keeping safe formatting (requires `sanitize` feature).
+    /// - `Trusted`: renders raw HTML with **no sanitization** — XSS risk with user content.
     #[props(default)]
     html_render_policy: HtmlRenderPolicy,
     /// CSS class prefix for syntax-highlighted code spans.

--- a/crates/markdown/src/lib.rs
+++ b/crates/markdown/src/lib.rs
@@ -1,3 +1,20 @@
+//! # Security
+//!
+//! Raw HTML in markdown is a potential XSS vector. This crate provides three
+//! rendering policies via [`HtmlRenderPolicy`](types::HtmlRenderPolicy):
+//!
+//! - **`Escape`** (default) — HTML tags are rendered as visible text. Safe for
+//!   all inputs including untrusted user content.
+//! - **`Sanitized`** — HTML is cleaned with the [`ammonia`](https://docs.rs/ammonia)
+//!   crate, stripping `<script>`, `<iframe>`, event handlers, etc. while keeping
+//!   safe formatting tags. Requires the `sanitize` Cargo feature.
+//! - **`Trusted`** — HTML is injected directly into the DOM with **no sanitization**.
+//!   Only use when you fully control the markdown source. **This is an XSS vector
+//!   if used with user-generated content.**
+//!
+//! When in doubt, use the default `Escape` policy. If you need HTML rendering
+//! with user content, enable the `sanitize` feature and use `Sanitized`.
+
 pub mod components;
 pub mod context;
 pub mod highlight;

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -326,10 +326,19 @@ fn render_node(node: &AstNode, config: &RenderConfig) -> Element {
         }
         CustomEvent::Standard(Event::Html(h)) | CustomEvent::Standard(Event::InlineHtml(h)) => {
             let html = h.to_string();
-            if config.html_render_policy == HtmlRenderPolicy::Trusted {
-                rsx! { span { dangerous_inner_html: "{html}" } }
-            } else {
-                rsx! { span { "{html}" } }
+            match config.html_render_policy {
+                HtmlRenderPolicy::Trusted => {
+                    rsx! { span { dangerous_inner_html: "{html}" } }
+                }
+                #[cfg(feature = "sanitize")]
+                HtmlRenderPolicy::Sanitized => {
+                    let clean = ammonia::clean(&html);
+                    rsx! { span { dangerous_inner_html: "{clean}" } }
+                }
+                // Escape (default) — and Sanitized fallback when feature is disabled
+                _ => {
+                    rsx! { span { "{html}" } }
+                }
             }
         }
         CustomEvent::Standard(Event::TaskListMarker(checked)) => {

--- a/crates/markdown/src/tests.rs
+++ b/crates/markdown/src/tests.rs
@@ -2227,6 +2227,47 @@ mod html_policy_tests {
         assert!(html.contains("<b>"));
         assert!(html.contains("</b>"));
     }
+
+    #[cfg(feature = "sanitize")]
+    #[test]
+    fn sanitized_policy_strips_script_tags() {
+        let rope = crop::Rope::from("text <script>alert('xss')</script> end");
+        let doc = parse_document_with_policy(&rope, HtmlRenderPolicy::Sanitized);
+
+        let mut vdom = VirtualDom::new_with_props(|props: Element| props, doc.element);
+        vdom.rebuild_in_place();
+        let html = dioxus_ssr::render(&vdom);
+
+        assert!(!html.contains("<script>"), "script tags should be stripped");
+    }
+
+    #[cfg(feature = "sanitize")]
+    #[test]
+    fn sanitized_policy_preserves_safe_html() {
+        let rope = crop::Rope::from("before <b>bold</b> after");
+        let doc = parse_document_with_policy(&rope, HtmlRenderPolicy::Sanitized);
+
+        let mut vdom = VirtualDom::new_with_props(|props: Element| props, doc.element);
+        vdom.rebuild_in_place();
+        let html = dioxus_ssr::render(&vdom);
+
+        assert!(html.contains("<b>"), "safe tags should be preserved");
+        assert!(html.contains("</b>"), "safe closing tags should be preserved");
+    }
+
+    #[cfg(not(feature = "sanitize"))]
+    #[test]
+    fn sanitized_policy_falls_back_to_escape_without_feature() {
+        let rope = crop::Rope::from("before <b>bold</b> after");
+        let doc = parse_document_with_policy(&rope, HtmlRenderPolicy::Sanitized);
+
+        let mut vdom = VirtualDom::new_with_props(|props: Element| props, doc.element);
+        vdom.rebuild_in_place();
+        let html = dioxus_ssr::render(&vdom);
+
+        // Without the sanitize feature, Sanitized falls back to Escape behavior
+        assert!(html.contains("&#60;b&#62;"));
+    }
 }
 
 // ── Syntax highlighting tests ────────────────────────────────────────

--- a/crates/markdown/src/types.rs
+++ b/crates/markdown/src/types.rs
@@ -318,16 +318,51 @@ impl PartialEq for ParsedDoc {
 
 // ── HTML render policy ───────────────────────────────────────────────
 
-/// Controls how raw HTML blocks and inline HTML are rendered.
+/// Controls how raw HTML blocks and inline HTML in markdown are rendered.
 ///
-/// By default, raw HTML is **escaped** (displayed as-is) to prevent XSS.
-/// Consumers who trust their markdown source can opt into `Trusted` rendering.
+/// By default, raw HTML is **escaped** (displayed as visible text) to prevent
+/// cross-site scripting (XSS) attacks. Choose a policy based on how much you
+/// trust the markdown source:
+///
+/// | Policy | Use when | XSS safe? |
+/// |-----------|----------------------------------------------|-----------|
+/// | `Escape` | Untrusted / user-generated markdown (default)| Yes |
+/// | `Sanitized` | User-generated markdown where you want HTML formatting but not scripts (requires `sanitize` feature) | Yes |
+/// | `Trusted` | You control the markdown source entirely | **No** |
+///
+/// # Security
+///
+/// **`Trusted` mode renders arbitrary HTML without any sanitization.** If the
+/// markdown contains `<script>`, `<iframe>`, `onload=`, or any other active
+/// content, it **will** be injected into the DOM. Never use `Trusted` with
+/// user-generated or untrusted markdown — this is a direct XSS vector.
+///
+/// For user-generated content that needs HTML rendering, enable the `sanitize`
+/// feature and use [`HtmlRenderPolicy::Sanitized`], which strips dangerous
+/// elements and attributes via the [`ammonia`](https://docs.rs/ammonia) crate.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HtmlRenderPolicy {
-    /// Escape HTML — render as visible text. Safe default.
+    /// Escape HTML — render as visible text. Safe for all inputs.
     #[default]
     Escape,
-    /// Render raw HTML via `dangerous_inner_html`. Only use with trusted input.
+
+    /// Sanitize HTML with [`ammonia`](https://docs.rs/ammonia) before rendering.
+    ///
+    /// Strips dangerous elements (`<script>`, `<iframe>`, `<object>`, etc.) and
+    /// event-handler attributes (`onload`, `onclick`, etc.) while preserving safe
+    /// formatting tags (`<b>`, `<i>`, `<a>`, `<code>`, etc.).
+    ///
+    /// Requires the `sanitize` Cargo feature. Falls back to `Escape` if the
+    /// feature is not enabled.
+    Sanitized,
+
+    /// Render raw HTML via `dangerous_inner_html` **without any sanitization**.
+    ///
+    /// # Security Warning
+    ///
+    /// **This is a direct XSS vector.** Only use this when you fully control the
+    /// markdown source (e.g., static content compiled into your binary). Never
+    /// use with user-generated input.
     Trusted,
 }
 


### PR DESCRIPTION
Add a `Sanitized` variant to `HtmlRenderPolicy` that uses the `ammonia`
crate to strip dangerous HTML (script, iframe, event handlers) while
preserving safe formatting tags. Available behind a `sanitize` Cargo
feature flag; falls back to `Escape` when the feature is disabled.

Add comprehensive XSS security documentation to the enum, crate-level
docs, and component props. Mark CI/CD and Security findings as
implemented in ARCHITECTURE-REVIEW.md.

https://claude.ai/code/session_01Uj9prjBkSuRQDr7MU21Par