### PR TITLE
refactor: unify workspace crate versions to single workspace-managed version

### DIFF
--- a/ARCHITECTURE-REVIEW.md
+++ b/ARCHITECTURE-REVIEW.md
@@ -97,7 +97,7 @@ The highlight.rs usage is acceptable (bounded, cached). ~~The noxpad usage leaks
 
 ---
 
-### [PRIORITY: Medium]
+### [IMPLEMENTED] ~~[PRIORITY: Medium]~~
 **Area:** Architecture — Version Inconsistency Across Crates
 **Problem:** Crate versions are wildly inconsistent:
 - cmdk: 0.13.0
@@ -108,6 +108,8 @@ The highlight.rs usage is acceptable (bounded, cached). ~~The noxpad usage leaks
 With a workspace-level edition of 2024 and pinned `dioxus = "=0.7.3"`, the version numbers suggest the cmdk crate has had 13 releases while others are effectively unreleased. This is confusing for consumers trying to understand compatibility.
 
 **Suggestion:** Either adopt a unified workspace version (all crates share the same version, bumped together) or document the versioning strategy. For a learning project, a unified version is simpler.
+
+**IMPLEMENTED**: Added `version = "0.13.0"` to `[workspace.package]` in the root `Cargo.toml`. All 17 crate `Cargo.toml` files (11 library crates, 1 demo app, 5 example apps) now use `version.workspace = true` to inherit the unified version. Version bumps are now a single-line change in the workspace root.
 
 **Expected Impact:** Clearer compatibility story; simpler dependency management.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "command-palette-adaptive"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "command-palette-example"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "command-palette-floating-example"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "command-palette-mobile"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "command-palette-pages"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-dnd"
-version = "0.2.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "gloo-timers",
@@ -1273,14 +1273,14 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-extensions"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
 ]
 
 [[package]]
 name = "dioxus-nox-gestures"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "gloo-timers",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-markdown"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "ammonia",
  "crop",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-preview"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "gloo-timers",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-shell"
-version = "0.2.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -1321,14 +1321,14 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-suggest"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
 ]
 
 [[package]]
 name = "dioxus-nox-tag-input"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-dnd",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-nox-virtualize"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
 ]
@@ -3151,7 +3151,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "noxpad"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-cmdk",
@@ -4651,7 +4651,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suggest-demo"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "dioxus",
  "dioxus-nox-suggest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/7A9599F5/dioxus-nox"

--- a/crates/cmdk/Cargo.toml
+++ b/crates/cmdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-cmdk"
-version = "0.13.0"
+version.workspace = true
 edition.workspace = true
 description = "A headless Command Palette primitive for Dioxus"
 license.workspace = true

--- a/crates/cmdk/examples/command_palette/Cargo.toml
+++ b/crates/cmdk/examples/command_palette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command-palette-example"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/cmdk/examples/command_palette_adaptive/Cargo.toml
+++ b/crates/cmdk/examples/command_palette_adaptive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command-palette-adaptive"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/cmdk/examples/command_palette_floating/Cargo.toml
+++ b/crates/cmdk/examples/command_palette_floating/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command-palette-floating-example"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/cmdk/examples/command_palette_mobile/Cargo.toml
+++ b/crates/cmdk/examples/command_palette_mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command-palette-mobile"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/cmdk/examples/command_palette_pages/Cargo.toml
+++ b/crates/cmdk/examples/command_palette_pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command-palette-pages"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/dnd/Cargo.toml
+++ b/crates/dnd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-dnd"
-version = "0.2.0"
+version.workspace = true
 edition.workspace = true
 description = "A composable drag-and-drop component library for Dioxus"
 license.workspace = true

--- a/crates/extensions/Cargo.toml
+++ b/crates/extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-extensions"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Runtime plugin system for Dioxus applications"
 license.workspace = true

--- a/crates/gestures/Cargo.toml
+++ b/crates/gestures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-gestures"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Touch gesture primitives (swipe-left reveal, long-press) for Dioxus WASM apps"
 license.workspace = true

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-markdown"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Headless markdown editor, previewer, and display components for Dioxus"
 license.workspace = true

--- a/crates/noxpad/Cargo.toml
+++ b/crates/noxpad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noxpad"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [dependencies]

--- a/crates/preview/Cargo.toml
+++ b/crates/preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-preview"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Debounced preview hook and LRU cache for navigable Dioxus lists"
 license.workspace = true

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-shell"
-version = "0.2.0"
+version.workspace = true
 edition.workspace = true
 description = "Application shell layout primitive for Dioxus"
 license.workspace = true

--- a/crates/suggest/Cargo.toml
+++ b/crates/suggest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-suggest"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Headless inline-trigger suggestion primitive — slash commands, @mentions, #hashtags"
 license.workspace = true

--- a/crates/suggest/examples/suggest-demo/Cargo.toml
+++ b/crates/suggest/examples/suggest-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suggest-demo"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 
 [[bin]]

--- a/crates/tag-input/Cargo.toml
+++ b/crates/tag-input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-tag-input"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Headless tag/multi-select input primitive for Dioxus"
 license.workspace = true

--- a/crates/virtualize/Cargo.toml
+++ b/crates/virtualize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-nox-virtualize"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Virtual list viewport math for Dioxus"
 license.workspace = true


### PR DESCRIPTION
All 17 crates now inherit version from workspace.package.version (0.13.0)
instead of maintaining independent version numbers. Version bumps are now
a single-line change in the root Cargo.toml.

https://claude.ai/code/session_01NZFNWifFKwRDFk62bf8h91