### PR TITLE
feat: add dioxus-nox umbrella crate with feature-gated re-exports

### DIFF
--- a/ARCHITECTURE-REVIEW.md
+++ b/ARCHITECTURE-REVIEW.md
@@ -162,11 +162,13 @@ The comments reference optimization tickets (P-050, P-051, P-052) indicating awa
 
 ---
 
-### [PRIORITY: Medium]
+### [IMPLEMENTED] ~~[PRIORITY: Medium]~~
 **Area:** Developer Experience — No Prelude or Unified Import
 **Problem:** There is no top-level `dioxus-nox` crate that re-exports all sub-crates. Consumers must individually depend on and import each crate (`dioxus-nox-cmdk`, `dioxus-nox-dnd`, `dioxus-nox-markdown`, etc.). The noxpad demo shows this results in 9 import lines just for library types.
 
-**Suggestion:** Create a `dioxus-nox` umbrella crate with feature-gated re-exports of each sub-crate. This is the standard pattern for workspace libraries (similar to `tokio`, `axum`).
+**Suggestion:** ~~Create a `dioxus-nox` umbrella crate with feature-gated re-exports of each sub-crate. This is the standard pattern for workspace libraries (similar to `tokio`, `axum`).~~
+
+**IMPLEMENTED**: Created `crates/dioxus-nox/` umbrella crate with feature-gated re-exports of all 10 library sub-crates. Each sub-crate is behind a feature flag (`cmdk`, `dnd`, `markdown`, `shell`, `suggest`, `tag-input`, `virtualize`, `preview`, `extensions`, `gestures`). A `full` feature enables everything. Default features include the most commonly used crates (`shell`, `cmdk`, `dnd`, `tag-input`, `suggest`, `preview`). Sub-crate features are forwarded (e.g., `cmdk-web`, `markdown-syntax-highlighting`, `dnd-styles`). A `prelude` module provides curated re-exports of the most common types and hooks.
 
 **Expected Impact:** Single dependency line for consumers; simpler getting-started experience.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-nox"
+version = "0.13.0"
+dependencies = [
+ "dioxus-nox-cmdk",
+ "dioxus-nox-dnd",
+ "dioxus-nox-extensions",
+ "dioxus-nox-gestures",
+ "dioxus-nox-markdown",
+ "dioxus-nox-preview",
+ "dioxus-nox-shell",
+ "dioxus-nox-suggest",
+ "dioxus-nox-tag-input",
+ "dioxus-nox-virtualize",
+]
+
+[[package]]
 name = "dioxus-nox-cmdk"
 version = "0.13.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/suggest",
     "crates/tag-input",
     "crates/markdown",
+    "crates/dioxus-nox",
     "crates/cmdk/examples/command_palette",
     "crates/cmdk/examples/command_palette_adaptive",
     "crates/cmdk/examples/command_palette_floating",
@@ -45,5 +46,7 @@ dioxus-nox-markdown = { path = "crates/markdown" }
 dioxus-nox-suggest = { path = "crates/suggest" }
 dioxus-nox-tag-input = { path = "crates/tag-input" }
 dioxus-nox-preview = { path = "crates/preview" }
+dioxus-nox-extensions = { path = "crates/extensions" }
 dioxus-nox-gestures = { path = "crates/gestures" }
+dioxus-nox = { path = "crates/dioxus-nox" }
 syntect = { version = "5.3", default-features = false }

--- a/crates/dioxus-nox/Cargo.toml
+++ b/crates/dioxus-nox/Cargo.toml
@@ -1,0 +1,68 @@
+[package]
+name = "dioxus-nox"
+version.workspace = true
+edition.workspace = true
+description = "Umbrella crate for the dioxus-nox headless component library"
+license.workspace = true
+repository.workspace = true
+keywords = ["dioxus", "components", "wasm", "ui"]
+categories = ["gui", "wasm", "web-programming"]
+
+[dependencies]
+dioxus-nox-cmdk       = { workspace = true, optional = true }
+dioxus-nox-dnd        = { workspace = true, optional = true }
+dioxus-nox-markdown   = { workspace = true, optional = true }
+dioxus-nox-shell      = { workspace = true, optional = true }
+dioxus-nox-suggest    = { workspace = true, optional = true }
+dioxus-nox-tag-input  = { workspace = true, optional = true }
+dioxus-nox-virtualize = { workspace = true, optional = true }
+dioxus-nox-preview    = { workspace = true, optional = true }
+dioxus-nox-extensions = { workspace = true, optional = true }
+dioxus-nox-gestures   = { workspace = true, optional = true }
+
+[features]
+default = ["shell", "cmdk", "dnd", "tag-input", "suggest", "preview"]
+
+# Per-crate gates
+cmdk       = ["dep:dioxus-nox-cmdk"]
+dnd        = ["dep:dioxus-nox-dnd"]
+markdown   = ["dep:dioxus-nox-markdown"]
+shell      = ["dep:dioxus-nox-shell"]
+suggest    = ["dep:dioxus-nox-suggest"]
+tag-input  = ["dep:dioxus-nox-tag-input"]
+virtualize = ["dep:dioxus-nox-virtualize"]
+preview    = ["dep:dioxus-nox-preview"]
+extensions = ["dep:dioxus-nox-extensions"]
+gestures   = ["dep:dioxus-nox-gestures"]
+
+# All-in-one
+full = [
+    "cmdk", "dnd", "markdown", "shell", "suggest",
+    "tag-input", "virtualize", "preview", "extensions", "gestures",
+]
+
+# Sub-crate feature pass-through
+cmdk-web       = ["cmdk", "dioxus-nox-cmdk/web"]
+cmdk-desktop   = ["cmdk", "dioxus-nox-cmdk/desktop"]
+cmdk-mobile    = ["cmdk", "dioxus-nox-cmdk/mobile"]
+cmdk-router    = ["cmdk", "dioxus-nox-cmdk/router"]
+cmdk-virtualize = ["cmdk", "dioxus-nox-cmdk/virtualize"]
+
+dnd-web     = ["dnd", "dioxus-nox-dnd/web"]
+dnd-desktop = ["dnd", "dioxus-nox-dnd/desktop"]
+dnd-mobile  = ["dnd", "dioxus-nox-dnd/mobile"]
+dnd-styles  = ["dnd", "dioxus-nox-dnd/styles"]
+
+markdown-web                 = ["markdown", "dioxus-nox-markdown/web"]
+markdown-desktop             = ["markdown", "dioxus-nox-markdown/desktop"]
+markdown-mobile              = ["markdown", "dioxus-nox-markdown/mobile"]
+markdown-syntax-highlighting = ["markdown", "dioxus-nox-markdown/syntax-highlighting"]
+markdown-sanitize            = ["markdown", "dioxus-nox-markdown/sanitize"]
+
+suggest-web     = ["suggest", "dioxus-nox-suggest/web"]
+suggest-desktop = ["suggest", "dioxus-nox-suggest/desktop"]
+suggest-mobile  = ["suggest", "dioxus-nox-suggest/mobile"]
+
+tag-input-web = ["tag-input", "dioxus-nox-tag-input/web"]
+
+virtualize-hooks = ["virtualize", "dioxus-nox-virtualize/hooks"]

--- a/crates/dioxus-nox/src/lib.rs
+++ b/crates/dioxus-nox/src/lib.rs
@@ -1,0 +1,98 @@
+//! # dioxus-nox
+//!
+//! Umbrella crate for the **dioxus-nox** headless component library.
+//!
+//! Enable individual crates via feature flags:
+//!
+//! ```toml
+//! [dependencies]
+//! dioxus-nox = { version = "0.13", features = ["cmdk", "markdown"] }
+//! ```
+//!
+//! Or enable everything:
+//!
+//! ```toml
+//! [dependencies]
+//! dioxus-nox = { version = "0.13", features = ["full"] }
+//! ```
+
+#[cfg(feature = "cmdk")]
+pub use dioxus_nox_cmdk as cmdk;
+
+#[cfg(feature = "dnd")]
+pub use dioxus_nox_dnd as dnd;
+
+#[cfg(feature = "markdown")]
+pub use dioxus_nox_markdown as markdown;
+
+#[cfg(feature = "shell")]
+pub use dioxus_nox_shell as shell;
+
+#[cfg(feature = "suggest")]
+pub use dioxus_nox_suggest as suggest;
+
+#[cfg(feature = "tag-input")]
+pub use dioxus_nox_tag_input as tag_input;
+
+#[cfg(feature = "virtualize")]
+pub use dioxus_nox_virtualize as virtualize;
+
+#[cfg(feature = "preview")]
+pub use dioxus_nox_preview as preview;
+
+#[cfg(feature = "extensions")]
+pub use dioxus_nox_extensions as extensions;
+
+#[cfg(feature = "gestures")]
+pub use dioxus_nox_gestures as gestures;
+
+/// Convenience re-exports of the most commonly used types.
+///
+/// ```rust,ignore
+/// use dioxus_nox::prelude::*;
+/// ```
+pub mod prelude {
+    #[cfg(feature = "cmdk")]
+    pub use dioxus_nox_cmdk::{
+        CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
+        CommandPalette, use_command_palette,
+    };
+
+    #[cfg(feature = "dnd")]
+    pub use dioxus_nox_dnd::prelude::{
+        ActiveDrag, AnnouncementEvent, CollisionStrategy, DragContext, DragContextProvider,
+        DragData, DragId, DragOverlay, DragState, DragType, Draggable, DropEvent, DropIndicator,
+        DropLocation, DropZone, DropZoneState, IndicatorPosition, MergeEvent, MoveEvent,
+        Orientation as DndOrientation, Position, Rect, ReorderEvent, SortableContext,
+        SortableGroup, SortableItem, SortableItemState,
+    };
+
+    #[cfg(feature = "markdown")]
+    pub use dioxus_nox_markdown::prelude::{
+        Mode, Orientation as MarkdownOrientation, highlight_code, parse_document,
+        use_markdown_context, use_markdown_handle,
+    };
+
+    #[cfg(feature = "shell")]
+    pub use dioxus_nox_shell::{AppShell, ShellContext, use_shell_breakpoint, use_shell_context};
+
+    #[cfg(feature = "suggest")]
+    pub use dioxus_nox_suggest::{TriggerConfig, TriggerSelectEvent, suggest, use_suggestion};
+
+    #[cfg(feature = "tag-input")]
+    pub use dioxus_nox_tag_input::{use_tag_input, use_tag_input_grouped};
+
+    #[cfg(feature = "virtualize")]
+    pub use dioxus_nox_virtualize::VirtualViewport;
+
+    #[cfg(feature = "preview")]
+    pub use dioxus_nox_preview::{
+        PreviewPosition, preview, use_debounced_active, use_preview_cache,
+    };
+
+    #[cfg(feature = "extensions")]
+    pub use dioxus_nox_extensions::{Extension, PluginCommand, use_extensions};
+
+    #[cfg(feature = "gestures")]
+    pub use dioxus_nox_gestures::{SwipeConfig, swipe_actions, use_long_press, use_swipe_gesture};
+}


### PR DESCRIPTION
Create a unified entry point for the component library so consumers
can depend on a single `dioxus-nox` crate instead of 9+ individual
crates. Each sub-crate is behind a feature flag with a `full` feature
to enable everything and a curated `prelude` module for common imports.

Implements the "No Prelude or Unified Import" item from ARCHITECTURE-REVIEW.md.

https://claude.ai/code/session_01BeRzJYzSKXHiAhvPX4yZ4r