### PR TITLE
refactor: DRY select highlight_* and dnd keyboard drop helpers

### DIFF
--- a/crates/dnd/src/context/provider.rs
+++ b/crates/dnd/src/context/provider.rs
@@ -16,6 +16,59 @@ use crate::patterns::sortable::item::NextAnimationFrame;
 use crate::types::{AnnouncementEvent, DropEvent, DropLocation, Position};
 use crate::utils::{extract_attribute, filter_class_style};
 
+/// Shared keyboard-drop logic invoked by both Space and Enter handlers.
+///
+/// Reads the active drag's id, current keyboard container, and index, then
+/// (if the drag ends successfully) dispatches a `Dropped` announcement,
+/// fires `on_drop`, and focuses the dropped item.
+/// Reconstruct the items list for a keyboard-drag container, with the
+/// currently dragged item appended at the end. Returns `None` if no drag
+/// is active.
+fn items_in_keyboard_container(
+    context: DragContext,
+    cid: &super::DragId,
+) -> Option<Vec<super::DragId>> {
+    let active_id = context.active.peek().as_ref().map(|a| a.data.id.clone())?;
+    let zones = context.drop_zones.peek();
+    let mut items = sorted_items_in_container(&zones, cid, Some(&active_id));
+    drop(zones);
+    items.push(active_id);
+    Some(items)
+}
+
+/// Shared keyboard-drop logic invoked by both Space and Enter handlers.
+fn handle_keyboard_drop(context: DragContext, on_drop: EventHandler<DropEvent>) {
+    let (item_id, cid, index, total) = {
+        let a = context.active.peek();
+        let id = a.as_ref().map(|a| a.data.id.clone());
+        let c = context.keyboard_container();
+        let i = *context.keyboard_index.peek();
+        // Compute real total: items in container + dragged item
+        let t = c
+            .as_ref()
+            .and_then(|cid| items_in_keyboard_container(context, cid).map(|i| i.len()));
+        (id, c, i, t)
+    };
+    let _focus_id = item_id.clone();
+    if let Some(event) = context.end_keyboard_drag() {
+        if let (Some(item_id), Some(cid), Some(idx), Some(total)) = (item_id, cid, index, total) {
+            context.dispatch_announcement(AnnouncementEvent::Dropped {
+                item_id,
+                position: idx + 1,
+                total,
+                container_id: cid,
+            });
+        }
+        on_drop.call(event);
+
+        // Focus the dropped item at its new position
+        #[cfg(target_arch = "wasm32")]
+        if let Some(focus_id) = _focus_id {
+            keyboard_focus_item(focus_id);
+        }
+    }
+}
+
 /// Props for the DragContextProvider component
 #[derive(Props, Clone)]
 pub struct DragContextProviderProps {
@@ -198,16 +251,6 @@ pub fn DragContextProvider(props: DragContextProviderProps) -> Element {
 
                 // During keyboard drag: handle navigation and drop
                 if context.is_keyboard_drag() {
-                    // Helper: reconstruct items list for current keyboard container
-                    let get_all_items = |cid: &super::DragId| -> Option<(Vec<super::DragId>, super::DragId)> {
-                        let active_id = context.active.peek().as_ref().map(|a| a.data.id.clone())?;
-                        let zones = context.drop_zones.peek();
-                        let mut items = sorted_items_in_container(&zones, cid, Some(&active_id));
-                        drop(zones);
-                        items.push(active_id.clone());
-                        Some((items, active_id))
-                    };
-
                     match key {
                         Key::Escape => {
                             let item_id = context.active.peek().as_ref().map(|a| a.data.id.clone());
@@ -219,7 +262,8 @@ pub fn DragContextProvider(props: DragContextProviderProps) -> Element {
                         }
                         Key::ArrowDown | Key::ArrowRight => {
                             if let Some(cid) = context.keyboard_container()
-                                && let Some((all_items, item_id)) = get_all_items(&cid)
+                                && let Some(item_id) = context.active.peek().as_ref().map(|a| a.data.id.clone())
+                                && let Some(all_items) = items_in_keyboard_container(context, &cid)
                             {
                                 if let Some((pos, total)) = context.keyboard_move(1, &all_items) {
                                     // Check if the new target is a group item — enter it
@@ -245,7 +289,8 @@ pub fn DragContextProvider(props: DragContextProviderProps) -> Element {
                         }
                         Key::ArrowUp | Key::ArrowLeft => {
                             if let Some(cid) = context.keyboard_container()
-                                && let Some((all_items, item_id)) = get_all_items(&cid)
+                                && let Some(item_id) = context.active.peek().as_ref().map(|a| a.data.id.clone())
+                                && let Some(all_items) = items_in_keyboard_container(context, &cid)
                             {
                                 if let Some((pos, total)) = context.keyboard_move(-1, &all_items) {
                                     // Check if the new target is a group item — enter it
@@ -270,63 +315,11 @@ pub fn DragContextProvider(props: DragContextProviderProps) -> Element {
                             e.prevent_default();
                         }
                         Key::Character(ref c) if c == " " => {
-                            // Keyboard drop (Space)
-                            let (item_id, cid, index, total) = {
-                                let a = context.active.peek();
-                                let id = a.as_ref().map(|a| a.data.id.clone());
-                                let c = context.keyboard_container();
-                                let i = *context.keyboard_index.peek();
-                                // Compute real total: items in container + dragged item
-                                let t = c.as_ref().and_then(|cid| {
-                                    get_all_items(cid).map(|(items, _)| items.len())
-                                });
-                                (id, c, i, t)
-                            };
-                            let _focus_id = item_id.clone();
-                            if let Some(event) = context.end_keyboard_drag() {
-                                if let (Some(item_id), Some(cid), Some(idx), Some(total)) = (item_id, cid, index, total) {
-                                    context.dispatch_announcement(AnnouncementEvent::Dropped {
-                                        item_id, position: idx + 1, total, container_id: cid,
-                                    });
-                                }
-                                on_drop.call(event);
-
-                                // Focus the dropped item at its new position
-                                #[cfg(target_arch = "wasm32")]
-                                if let Some(focus_id) = _focus_id {
-                                    keyboard_focus_item(focus_id);
-                                }
-                            }
+                            handle_keyboard_drop(context, on_drop);
                             e.prevent_default();
                         }
                         Key::Enter => {
-                            // Keyboard drop (Enter)
-                            let (item_id, cid, index, total) = {
-                                let a = context.active.peek();
-                                let id = a.as_ref().map(|a| a.data.id.clone());
-                                let c = context.keyboard_container();
-                                let i = *context.keyboard_index.peek();
-                                // Compute real total: items in container + dragged item
-                                let t = c.as_ref().and_then(|cid| {
-                                    get_all_items(cid).map(|(items, _)| items.len())
-                                });
-                                (id, c, i, t)
-                            };
-                            let _focus_id = item_id.clone();
-                            if let Some(event) = context.end_keyboard_drag() {
-                                if let (Some(item_id), Some(cid), Some(idx), Some(total)) = (item_id, cid, index, total) {
-                                    context.dispatch_announcement(AnnouncementEvent::Dropped {
-                                        item_id, position: idx + 1, total, container_id: cid,
-                                    });
-                                }
-                                on_drop.call(event);
-
-                                // Focus the dropped item at its new position
-                                #[cfg(target_arch = "wasm32")]
-                                if let Some(focus_id) = _focus_id {
-                                    keyboard_focus_item(focus_id);
-                                }
-                            }
+                            handle_keyboard_drop(context, on_drop);
                             e.prevent_default();
                         }
                         Key::Tab => {

--- a/crates/select/src/context.rs
+++ b/crates/select/src/context.rs
@@ -185,60 +185,47 @@ impl SelectContext {
 
     // ── Highlight navigation ─────────────────────────────────
 
-    /// Move highlight to the next visible non-disabled item.
-    pub fn highlight_next(&mut self) {
+    /// Shared logic for `highlight_*`: read items/visible/current, run a navigation
+    /// function, then commit the result and scroll it into view.
+    fn navigate_highlight(
+        &mut self,
+        f: impl FnOnce(&[ItemEntry], &[String], Option<&str>) -> Option<String>,
+    ) {
         let visible = self.visible_values.read();
         let items = self.items.read();
         let current = self.highlighted.read();
-        let next = navigation::navigate(&items, &visible, current.as_deref(), Direction::Forward);
+        let target = f(&items, &visible, current.as_deref());
         drop(visible);
         drop(items);
         drop(current);
-        self.highlighted.set(next.clone());
-        if let Some(ref val) = next {
+        self.highlighted.set(target.clone());
+        if let Some(ref val) = target {
             self.scroll_item_into_view(val);
         }
+    }
+
+    /// Move highlight to the next visible non-disabled item.
+    pub fn highlight_next(&mut self) {
+        self.navigate_highlight(|items, visible, current| {
+            navigation::navigate(items, visible, current, Direction::Forward)
+        });
     }
 
     /// Move highlight to the previous visible non-disabled item.
     pub fn highlight_prev(&mut self) {
-        let visible = self.visible_values.read();
-        let items = self.items.read();
-        let current = self.highlighted.read();
-        let prev = navigation::navigate(&items, &visible, current.as_deref(), Direction::Backward);
-        drop(visible);
-        drop(items);
-        drop(current);
-        self.highlighted.set(prev.clone());
-        if let Some(ref val) = prev {
-            self.scroll_item_into_view(val);
-        }
+        self.navigate_highlight(|items, visible, current| {
+            navigation::navigate(items, visible, current, Direction::Backward)
+        });
     }
 
     /// Move highlight to the first visible non-disabled item.
     pub fn highlight_first(&mut self) {
-        let visible = self.visible_values.read();
-        let items = self.items.read();
-        let target = navigation::first(&items, &visible);
-        drop(visible);
-        drop(items);
-        self.highlighted.set(target.clone());
-        if let Some(ref val) = target {
-            self.scroll_item_into_view(val);
-        }
+        self.navigate_highlight(|items, visible, _| navigation::first(items, visible));
     }
 
     /// Move highlight to the last visible non-disabled item.
     pub fn highlight_last(&mut self) {
-        let visible = self.visible_values.read();
-        let items = self.items.read();
-        let target = navigation::last(&items, &visible);
-        drop(visible);
-        drop(items);
-        self.highlighted.set(target.clone());
-        if let Some(ref val) = target {
-            self.scroll_item_into_view(val);
-        }
+        self.navigate_highlight(|items, visible, _| navigation::last(items, visible));
     }
 
     /// Type-ahead: find the first matching item by prefix.


### PR DESCRIPTION
## Summary
- **#46** — Extract `SelectContext::navigate_highlight` helper; collapse `highlight_next/prev/first/last` from ~70 lines to one-liners.
- **#45** — Hoist `handle_keyboard_drop` out of `DragContextProvider`'s `onkeydown` closure, and additionally hoist `get_all_items` to a free function `items_in_keyboard_container` with a simpler `Option<Vec<DragId>>` return. The previous tuple return was a leaky abstraction — only 2 of 4 callers used the bundled `active_id`. Dropping it lets `handle_keyboard_drop` take just `(DragContext, EventHandler<DropEvent>)` with no closure parameter, avoiding a `clippy::type_complexity` suppression entirely.

Pure refactors. No behavior changes. No public API changes.

Closes #45
Closes #46

## Test plan
- [x] `cargo test -p dioxus-nox-select -p dioxus-nox-dnd`
- [x] `cargo clippy -p dioxus-nox-select -p dioxus-nox-dnd --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo fmt`
- [x] Manual: Select keyboard nav (arrows, Home/End, type-ahead) in noxpad
- [x] Manual: DnD keyboard drag — pick up with Space, navigate, drop with both Space and Enter, in sortable + kanban

🤖 Generated with [Claude Code](https://claude.com/claude-code)