### PR TITLE
fix(dnd): consolidate keyboard drag lifecycle ownership (#58)

### DIFF
--- a/crates/dnd/src/context/mod.rs
+++ b/crates/dnd/src/context/mod.rs
@@ -293,6 +293,22 @@ pub struct DragContext {
     /// Unique ID for the ARIA instructions element, ensuring no duplicates
     /// when multiple DragContextProviders exist on the same page.
     pub(super) instructions_id: Signal<String>,
+    /// Currently focused sortable item (set onfocusin / cleared onfocusout
+    /// by `SortableItem`). The provider's keyboard handler peeks this on
+    /// Space/Enter to start a keyboard drag. Single owner of activation.
+    pub(super) focused_sortable: Signal<Option<FocusedSortable>>,
+}
+
+/// Snapshot of a focused sortable item, used by the provider to start a
+/// keyboard drag from a single owner. Captured at focusin time.
+#[derive(Clone, PartialEq)]
+pub struct FocusedSortable {
+    pub id: DragId,
+    pub container_id: DragId,
+    pub items: Vec<DragId>,
+    pub index: usize,
+    pub drag_types: Vec<DragType>,
+    pub disabled: bool,
 }
 
 impl DragContext {
@@ -319,6 +335,7 @@ impl DragContext {
             keyboard_container: Signal::new(None),
             active_pointer_id: Signal::new(None),
             instructions_id: Signal::new(format!("dxdnd-drag-instructions-{}", id)),
+            focused_sortable: Signal::new(None),
         }
     }
 
@@ -345,6 +362,7 @@ impl DragContext {
             keyboard_container: Signal::new(None),
             active_pointer_id: Signal::new(None),
             instructions_id: Signal::new(format!("dxdnd-drag-instructions-{}", id)),
+            focused_sortable: Signal::new(None),
         }
     }
 
@@ -683,6 +701,20 @@ impl DragContext {
     ///
     /// Calls the `on_announce` callback (if set), then updates the ARIA live
     /// region with the event's default English text.
+    /// Set (or clear) the currently focused sortable item. Called by
+    /// `SortableItem` from its `onfocusin`/`onfocusout` handlers. The
+    /// provider's keyboard handler reads this on Space/Enter to start a
+    /// keyboard drag from a single owner.
+    pub fn set_focused_sortable(&self, focused: Option<FocusedSortable>) {
+        let mut sig = self.focused_sortable;
+        sig.set(focused);
+    }
+
+    /// Peek the currently focused sortable item without subscribing.
+    pub fn focused_sortable(&self) -> Option<FocusedSortable> {
+        self.focused_sortable.peek().clone()
+    }
+
     pub fn dispatch_announcement(&self, event: AnnouncementEvent) {
         if let Some(handler) = self.on_announce.peek().as_ref() {
             handler.call(event.clone());

--- a/crates/dnd/src/context/provider.rs
+++ b/crates/dnd/src/context/provider.rs
@@ -13,7 +13,7 @@ use super::{DragContext, sorted_items_in_container};
 use crate::collision::CollisionStrategy;
 #[cfg(target_arch = "wasm32")]
 use crate::patterns::sortable::item::NextAnimationFrame;
-use crate::types::{AnnouncementEvent, DropEvent, DropLocation, Position};
+use crate::types::{AnnouncementEvent, DragData, DropEvent, DropLocation, Position};
 use crate::utils::{extract_attribute, filter_class_style};
 
 /// Shared keyboard-drop logic invoked by both Space and Enter handlers.
@@ -34,6 +34,33 @@ fn items_in_keyboard_container(
     drop(zones);
     items.push(active_id);
     Some(items)
+}
+
+/// Start a keyboard drag from the currently focused `SortableItem`. Single
+/// owner of keyboard activation — `SortableItem` only registers focus, this
+/// is the only place that calls `start_keyboard_drag`. Returns true if a
+/// drag was started so the caller can `prevent_default()` on the event.
+///
+/// Note: standalone `Draggable::onkeydown` also handles Space/Enter activation
+/// for non-sortable draggables. Those use `ctx.start_drag` (pointer-drag
+/// state), so `is_keyboard_drag()` stays false and the provider's keyboard
+/// branch never fires for them — no double-handle race.
+fn start_keyboard_drag_from_focus(context: DragContext) -> bool {
+    let Some(focused) = context.focused_sortable() else {
+        return false;
+    };
+    if focused.disabled || context.is_dragging() {
+        return false;
+    }
+    let data = DragData::with_types(focused.id.clone(), focused.drag_types.clone());
+    context.start_keyboard_drag(
+        data,
+        focused.id.clone(),
+        focused.container_id.clone(),
+        &focused.items,
+        focused.index,
+    );
+    true
 }
 
 /// Shared keyboard-drop logic invoked by both Space and Enter handlers.
@@ -407,10 +434,26 @@ pub fn DragContextProvider(props: DragContextProviderProps) -> Element {
                     return;
                 }
 
-                // Not in keyboard drag: Escape cancels pointer drag
-                if key == Key::Escape && context.is_dragging() {
-                    context.cancel_drag();
-                    e.prevent_default();
+                // Not in keyboard drag yet.
+                match key {
+                    // Activation: Space/Enter on a focused SortableItem starts
+                    // a keyboard drag. This is the single owner of activation —
+                    // SortableItem only registers focus, never starts drags.
+                    Key::Character(ref c) if c == " " => {
+                        if start_keyboard_drag_from_focus(context) {
+                            e.prevent_default();
+                        }
+                    }
+                    Key::Enter => {
+                        if start_keyboard_drag_from_focus(context) {
+                            e.prevent_default();
+                        }
+                    }
+                    Key::Escape if context.is_dragging() => {
+                        context.cancel_drag();
+                        e.prevent_default();
+                    }
+                    _ => {}
                 }
             },
             ..remaining_attrs,

--- a/crates/dnd/src/patterns/sortable/item.rs
+++ b/crates/dnd/src/patterns/sortable/item.rs
@@ -620,29 +620,38 @@ pub fn SortableItem(props: SortableItemProps) -> Element {
         ctx.start_pointer_drag(data, id_for_start.clone(), position, e.data().pointer_id());
     };
 
-    let id_for_keyboard = props.id.clone();
-    let drag_types_for_keyboard = all_drag_types.clone();
-    let disabled_for_keyboard = props.disabled;
-    let onkeydown = move |e: KeyboardEvent| {
-        let key = e.key();
-
-        // Space/Enter: start a keyboard drag (when not already dragging and not disabled)
-        if matches!(key, Key::Character(ref c) if c == " ") || key == Key::Enter {
-            e.prevent_default();
-
-            if disabled_for_keyboard || ctx.is_dragging() {
-                return;
-            }
-
-            let items = sortable.items.read();
-            let my_index = items.iter().position(|id| id == &id_for_keyboard);
-
-            if let Some(idx) = my_index {
-                let data =
-                    DragData::with_types(id_for_keyboard.clone(), drag_types_for_keyboard.clone());
-                let container_id = sortable.container_id.read().clone();
-                ctx.start_keyboard_drag(data, id_for_keyboard.clone(), container_id, &items, idx);
-            }
+    // Focus tracking: register on focusin, clear on focusout. The provider's
+    // single onkeydown handler reads `ctx.focused_sortable()` on Space/Enter
+    // to start the keyboard drag. SortableItem never starts drags directly —
+    // this avoids the dual-handler bubble race that previously cancelled the
+    // drag in the same event tick (#58).
+    let id_for_focus_in = props.id.clone();
+    let drag_types_for_focus = all_drag_types.clone();
+    let disabled_for_focus = props.disabled;
+    let onfocusin = move |_e: FocusEvent| {
+        let items_snapshot = sortable.items.read().clone();
+        let Some(idx) = items_snapshot.iter().position(|id| id == &id_for_focus_in) else {
+            return;
+        };
+        let container_id = sortable.container_id.read().clone();
+        ctx.set_focused_sortable(Some(crate::context::FocusedSortable {
+            id: id_for_focus_in.clone(),
+            container_id,
+            items: items_snapshot,
+            index: idx,
+            drag_types: drag_types_for_focus.clone(),
+            disabled: disabled_for_focus,
+        }));
+    };
+    let id_for_focus_out = props.id.clone();
+    let onfocusout = move |_e: FocusEvent| {
+        // Only clear if we're still the registered focus — sibling focus
+        // moves fire focusout(prev) before focusin(next); the new focusin
+        // will overwrite, so don't stomp on it here.
+        if let Some(focused) = ctx.focused_sortable()
+            && focused.id == id_for_focus_out
+        {
+            ctx.set_focused_sortable(None);
         }
     };
 
@@ -682,7 +691,8 @@ pub fn SortableItem(props: SortableItemProps) -> Element {
             "data-dnd-handle-mode": if has_handle { "true" },
             // Pointer handlers (inlined from Draggable)
             onpointerdown: start_drag,
-            onkeydown: onkeydown,
+            onfocusin: onfocusin,
+            onfocusout: onfocusout,
             oncontextmenu: move |e: Event<MouseData>| {
                 e.prevent_default();
             },

--- a/crates/dnd/src/primitives/dropzone.rs
+++ b/crates/dnd/src/primitives/dropzone.rs
@@ -282,8 +282,26 @@ pub fn DropZone(props: DropZoneProps) -> Element {
     let zone_disabled = props.disabled;
     let on_drop = props.on_drop;
 
-    // Keyboard handler: Space/Enter completes drop onto this zone
+    // Keyboard handler: Space/Enter completes drop onto this zone.
+    //
+    // CRITICAL: only handle keydowns that originated on this DropZone element,
+    // not events bubbling from focusable descendants (e.g. a `SortableItem`
+    // inside a `SortableContext` wrapped in a DropZone). Without this guard,
+    // pressing Space on a child sortable item would bubble here, end the
+    // drag, and the provider's activation arm would then start a fresh one
+    // on the next event tick — see #58.
     let onkeydown = move |e: KeyboardEvent| {
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Some(web_event) = e.data().downcast::<web_sys::KeyboardEvent>() {
+                let target = web_event.target();
+                let current = web_event.current_target();
+                if target != current {
+                    return;
+                }
+            }
+        }
+
         let key = e.key();
 
         // Check drag state at event time (not stale closure capture)

--- a/crates/noxpad/playwright-py/README.md
+++ b/crates/noxpad/playwright-py/README.md
@@ -1,0 +1,34 @@
+# noxpad Python Playwright tests
+
+Reusable Python E2E tests against the noxpad demo app. Parallel to the
+existing TypeScript suite in `../playwright/`.
+
+## Setup
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install playwright pytest pytest-playwright
+.venv/bin/playwright install chromium
+```
+
+## Run
+
+Start noxpad in one terminal:
+
+```bash
+dx serve -p noxpad --port 8911
+```
+
+Then in another:
+
+```bash
+NOXPAD_URL=http://localhost:8911 .venv/bin/pytest -v
+```
+
+Set `HEADLESS=0` to watch the browser.
+
+## Tests
+
+| File | Covers | Related issue |
+|---|---|---|
+| `test_keyboard_drag.py` | dnd keyboard drop (Space/Enter) and Escape cancel | #45 |

--- a/crates/noxpad/playwright-py/test_keyboard_drag.py
+++ b/crates/noxpad/playwright-py/test_keyboard_drag.py
@@ -1,0 +1,168 @@
+"""End-to-end keyboard drag-and-drop test for noxpad.
+
+Exercises the dnd keyboard-drop code path that issue #45 refactored:
+both the Space-arm and Enter-arm of `DragContextProvider`'s onkeydown handler
+go through the same `handle_keyboard_drop` helper. This test verifies that
+both keys still successfully reorder items.
+
+Run:
+    python3 -m venv .venv
+    .venv/bin/pip install playwright pytest pytest-playwright
+    .venv/bin/playwright install chromium
+    NOXPAD_URL=http://localhost:8911 .venv/bin/pytest test_keyboard_drag.py -v
+
+The dev server must already be running:
+    dx serve -p noxpad --port 8911
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from playwright.sync_api import Page, expect, sync_playwright
+
+NOXPAD_URL = os.environ.get("NOXPAD_URL", "http://localhost:8911")
+DRAG_ITEM = "[data-dnd-id]"
+
+
+@pytest.fixture(scope="session")
+def browser():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=os.environ.get("HEADLESS", "1") == "1")
+        yield browser
+        browser.close()
+
+
+@pytest.fixture
+def page(browser) -> Page:
+    context = browser.new_context()
+    page = context.new_page()
+    page.goto(NOXPAD_URL)
+    # Wait for hydration: items render after WASM boots.
+    page.wait_for_selector(DRAG_ITEM, timeout=15_000)
+    yield page
+    context.close()
+
+
+def get_item_order(page: Page) -> list[str]:
+    """Return the current ordered list of all draggable item IDs."""
+    return page.eval_on_selector_all(
+        DRAG_ITEM, "els => els.map(e => e.getAttribute('data-dnd-id'))"
+    )
+
+
+def keyboard_drag(page: Page, item_id: str, *, drop_key: str, steps: int = 1) -> None:
+    """Pick up `item_id` with Space, ArrowDown `steps` times, drop with `drop_key`.
+
+    `drop_key` must be either ' ' (Space) or 'Enter' — the two keys that
+    `handle_keyboard_drop` services in DragContextProvider.
+    """
+    assert drop_key in (" ", "Enter"), "drop_key must be Space or Enter"
+
+    item = page.locator(f'{DRAG_ITEM}[data-dnd-id="{item_id}"]').first
+    item.scroll_into_view_if_needed()
+    item.focus()
+    expect(item).to_be_focused()
+
+    # Pick up with Space
+    page.keyboard.press(" ")
+    # Move
+    for _ in range(steps):
+        page.keyboard.press("ArrowDown")
+    # Drop
+    page.keyboard.press(drop_key)
+    # Allow the next animation frame for DOM commit.
+    page.wait_for_timeout(150)
+
+
+@pytest.mark.parametrize("drop_key,label", [(" ", "Space"), ("Enter", "Enter")])
+def test_keyboard_drop_completes_without_immediate_cancel(
+    page: Page, drop_key: str, label: str
+) -> None:
+    """Regression guard for issue #58.
+
+    Before the fix, pressing Space on a focused `SortableItem` started a
+    keyboard drag and immediately ended it within the same event tick (the
+    `SortableItem`'s and `DragContextProvider`'s `onkeydown` handlers both
+    fired on the bubbling Space, the second one calling `handle_keyboard_drop`
+    against a freshly-grabbed drag and announcing
+    "Drop cancelled, item returned to start").
+
+    The fix moves keyboard activation onto the provider as the single owner
+    of keyboard drag lifecycle, and stops `DropZone`'s onkeydown from acting
+    on bubbled child events. After the fix:
+      - pressing Space puts the wrapper into keyboard-drag mode
+      - the announcement after Space is "Grabbed item, …", not "Drop cancelled"
+      - ArrowDown advances the cursor (announces "Position N of M")
+      - the drop key fires `handle_keyboard_drop` which announces "Item dropped, …"
+
+    The DOM-order assertion is intentionally not part of this test: noxpad's
+    folder reorder reactivity is a separate, pre-existing issue (verified
+    against `origin/main` with pointer drag) that is out of scope for #58.
+    """
+    before = get_item_order(page)
+    assert len(before) >= 2, f"need at least 2 draggable items, got {before}"
+
+    target = before[0]
+    item = page.locator(f'{DRAG_ITEM}[data-dnd-id="{target}"]').first
+    item.scroll_into_view_if_needed()
+    item.focus()
+    expect(item).to_be_focused()
+
+    live_region = page.locator('[role="status"]').first
+
+    # Pick up with Space.
+    page.keyboard.press(" ")
+    page.wait_for_timeout(100)
+    grab_text = live_region.text_content() or ""
+    assert "Grabbed" in grab_text, (
+        f"{label}: Space did not start a keyboard drag (announcement: {grab_text!r})"
+    )
+    assert "cancelled" not in grab_text.lower(), (
+        f"{label}: Space immediately cancelled the drag (announcement: {grab_text!r}) — #58 regression"
+    )
+    assert page.locator("[data-keyboard-active]").count() >= 1, (
+        f"{label}: [data-keyboard-active] never appeared on the wrapper"
+    )
+
+    # Advance one position; should announce a new position, not cancel.
+    page.keyboard.press("ArrowDown")
+    page.wait_for_timeout(100)
+    move_text = live_region.text_content() or ""
+    assert "Position" in move_text, (
+        f"{label}: ArrowDown did not move the keyboard cursor (announcement: {move_text!r})"
+    )
+
+    # Drop with the parametrized key. Must announce "Item dropped", not cancel.
+    page.keyboard.press(drop_key)
+    page.wait_for_timeout(200)
+    drop_text = live_region.text_content() or ""
+    assert "dropped" in drop_text.lower(), (
+        f"{label}: drop key did not commit the drag (announcement: {drop_text!r})"
+    )
+    assert "cancelled" not in drop_text.lower(), (
+        f"{label}: drop key was treated as a cancel (announcement: {drop_text!r}) — #58 regression"
+    )
+
+
+def test_escape_cancels_keyboard_drag(page: Page) -> None:
+    """Escape during a keyboard drag must restore the original order.
+
+    Sanity-check the inverse: keyboard drag started but cancelled.
+    """
+    before = get_item_order(page)
+    target = before[0]
+
+    item = page.locator(f'{DRAG_ITEM}[data-dnd-id="{target}"]').first
+    item.scroll_into_view_if_needed()
+    item.focus()
+    page.keyboard.press(" ")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(150)
+
+    after = get_item_order(page)
+    assert before == after, (
+        f"Escape did not cancel drag.\n  before: {before}\n  after:  {after}"
+    )


### PR DESCRIPTION
## Summary
- Fixes #58: pressing Space/Enter on a focused `SortableItem` started a keyboard drag and immediately ended it within the same event tick.
- Two sibling owners of keyboard drag-end logic each fired on the bubbling key event. Consolidates ownership: `DragContextProvider` is now the single owner of keyboard drag activation, and `DropZone::onkeydown` ignores bubbled events from focusable descendants.

## Changes
- **`crates/dnd/src/context/mod.rs`** — new `FocusedSortable` struct and `set_focused_sortable` / `focused_sortable` accessors on `DragContext`.
- **`crates/dnd/src/patterns/sortable/item.rs`** — deletes the bubble-racing `onkeydown` activation closure; replaces it with `onfocusin`/`onfocusout` that register/clear `focused_sortable` (id-guarded clear so sibling focus moves don't stomp).
- **`crates/dnd/src/context/provider.rs`** — adds `start_keyboard_drag_from_focus` helper; the provider's `onkeydown` now owns activation in its non-drag branch.
- **`crates/dnd/src/primitives/dropzone.rs`** — `DropZone::onkeydown` only handles events whose `target == currentTarget`. Without this, pressing Space on a child `SortableItem` would bubble to the wrapping `DropZone` and call `end_drag()` before the provider saw the event.

## Test plan
- [x] `cargo test -p dioxus-nox-dnd` — 272 passed
- [x] `cargo clippy --workspace --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] New Python Playwright regression guard `crates/noxpad/playwright-py/test_keyboard_drag.py` (3 passed) — asserts the aria-live announcement sequence (`Grabbed` → `Position N of M` → `Item dropped`) and that the cancel announcement never fires for a successful drop. Run with `dx serve -p noxpad --port 8911` then `pytest crates/noxpad/playwright-py/test_keyboard_drag.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)