### PR TITLE
fix(markdown): resolve the inline live-preview editor defect cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,7 +3404,6 @@ dependencies = [
  "dioxus-nox-preview",
  "dioxus-nox-shell",
  "dioxus-nox-suggest",
- "dioxus-nox-tag-input",
 ]
 
 [[package]]

--- a/crates/dnd/src/context/provider.rs
+++ b/crates/dnd/src/context/provider.rs
@@ -439,15 +439,13 @@ pub fn DragContextProvider(props: DragContextProviderProps) -> Element {
                     // Activation: Space/Enter on a focused SortableItem starts
                     // a keyboard drag. This is the single owner of activation —
                     // SortableItem only registers focus, never starts drags.
-                    Key::Character(ref c) if c == " " => {
-                        if start_keyboard_drag_from_focus(context) {
-                            e.prevent_default();
-                        }
+                    Key::Character(ref c)
+                        if c == " " && start_keyboard_drag_from_focus(context) =>
+                    {
+                        e.prevent_default();
                     }
-                    Key::Enter => {
-                        if start_keyboard_drag_from_focus(context) {
-                            e.prevent_default();
-                        }
+                    Key::Enter if start_keyboard_drag_from_focus(context) => {
+                        e.prevent_default();
                     }
                     Key::Escape if context.is_dragging() => {
                         context.cancel_drag();

--- a/crates/dnd/src/patterns/sortable/context.rs
+++ b/crates/dnd/src/patterns/sortable/context.rs
@@ -728,10 +728,9 @@ fn compute_nested_displacement(
                 .as_ref()
                 .and_then(|src_cid| ctx.find_nested_parent(src_cid))
                 .and_then(|parent_id| {
-                    parent_items
-                        .iter()
-                        .position(|id| id == &parent_id)
-                        .map(|idx| (idx, parent_id))
+                    // Not Option::zip: `parent_id` is needed to compute the position.
+                    let idx = parent_items.iter().position(|id| id == &parent_id)?;
+                    Some((idx, parent_id))
                 });
             if let Some((idx, parent_id)) = nested_source {
                 (Some(idx), ctx.get_zone_size(&parent_id))

--- a/crates/dnd/src/patterns/sortable/item.rs
+++ b/crates/dnd/src/patterns/sortable/item.rs
@@ -956,10 +956,9 @@ fn compute_displacement(
                 .as_ref()
                 .and_then(|src_cid| ctx.find_nested_parent(src_cid))
                 .and_then(|parent_id| {
-                    items
-                        .iter()
-                        .position(|id| id == &parent_id)
-                        .map(|idx| (idx, parent_id))
+                    // Not Option::zip: `parent_id` is needed to compute the position.
+                    let idx = items.iter().position(|id| id == &parent_id)?;
+                    Some((idx, parent_id))
                 });
             if let Some((idx, parent_id)) = nested_source {
                 (Some(idx), ctx.get_zone_size(&parent_id))

--- a/crates/dnd/src/primitives/draggable.rs
+++ b/crates/dnd/src/primitives/draggable.rs
@@ -473,11 +473,9 @@ pub fn Draggable(props: DraggableProps) -> Element {
                     on_start.call(id_for_keyboard.clone());
                 }
             }
-            Key::Escape => {
-                if ctx.is_dragging() {
-                    ctx.cancel_drag();
-                    e.prevent_default();
-                }
+            Key::Escape if ctx.is_dragging() => {
+                ctx.cancel_drag();
+                e.prevent_default();
             }
             _ => {}
         }

--- a/crates/dnd/src/primitives/dropzone.rs
+++ b/crates/dnd/src/primitives/dropzone.rs
@@ -337,11 +337,9 @@ pub fn DropZone(props: DropZoneProps) -> Element {
                     on_drop.call(event);
                 }
             }
-            Key::Escape => {
-                if dragging {
-                    ctx.cancel_drag();
-                    e.prevent_default();
-                }
+            Key::Escape if dragging => {
+                ctx.cancel_drag();
+                e.prevent_default();
             }
             _ => {}
         }

--- a/crates/dnd/src/sortable_projection.rs
+++ b/crates/dnd/src/sortable_projection.rs
@@ -56,12 +56,8 @@ pub(crate) fn compute_displacement_offset(
             }
         }
         // Drag out: source here, target elsewhere/none
-        (Some(src), None) => {
-            if my_idx >= src {
-                -dragged_size // Shift up/left to fill gap
-            } else {
-                0.0
-            }
+        (Some(src), None) if my_idx >= src => {
+            -dragged_size // Shift up/left to fill gap
         }
         // Drag in: source elsewhere, target here
         (None, Some(tgt)) => {

--- a/crates/gestures/src/swipe.rs
+++ b/crates/gestures/src/swipe.rs
@@ -167,13 +167,11 @@ pub fn use_swipe_gesture(config: SwipeConfig, on_commit: EventHandler<()>) -> Sw
             }
 
             match current_phase {
-                SwipePhase::Idle => {
-                    // Enter dragging once past the deadzone (only leftward).
-                    if dx.abs() > DEADZONE_PX && dx < 0.0 {
-                        phase.set(SwipePhase::Dragging);
-                        let clamped = dx.max(-cfg.action_width_px).min(0.0);
-                        offset_px.set(clamped);
-                    }
+                // Enter dragging once past the deadzone (only leftward).
+                SwipePhase::Idle if dx.abs() > DEADZONE_PX && dx < 0.0 => {
+                    phase.set(SwipePhase::Dragging);
+                    let clamped = dx.max(-cfg.action_width_px).min(0.0);
+                    offset_px.set(clamped);
                 }
                 SwipePhase::Dragging => {
                     let clamped = dx.max(-cfg.action_width_px).min(0.0);

--- a/crates/markdown/src/inline_editor.rs
+++ b/crates/markdown/src/inline_editor.rs
@@ -19,10 +19,7 @@ enum PendingCaretRestore {
     /// visibility after a reparse.
     Raw(usize),
     /// Visible UTF-16 offsets for a non-collapsed selection.
-    Selection {
-        start: usize,
-        end: usize,
-    },
+    Selection { start: usize, end: usize },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/markdown/src/inline_editor.rs
+++ b/crates/markdown/src/inline_editor.rs
@@ -374,6 +374,9 @@ fn TokenAwareBlockEditor(
                     // Arrow navigation for empty blocks
                     if key == "ArrowUp" || key == "ArrowDown" {
                         evt.prevent_default();
+                        // NOTE (#75): the visual-line sub-issues (multi-line block caret
+                        // trap; soft-wrapped single raw line treated as one visual line)
+                        // remain unaddressed — they need DOM line geometry.
                         if let Some(mut cctx) = cursor_ctx {
                             let parsed = (ctx.parsed_doc)();
                             let raw_nav = ctx.raw_value();
@@ -383,22 +386,36 @@ fn TokenAwareBlockEditor(
                             } else {
                                 NavDirection::Next
                             };
-                            let mut nodes = Vec::new();
-                            collect_editable_nodes(&augmented, &mut nodes);
-                            let target = match direction {
-                                NavDirection::Prev => nodes
-                                    .iter()
-                                    .rev()
-                                    .find(|n| n.range.start < safe_start)
-                                    .map(|n| n.range.start),
-                                NavDirection::Next => nodes
-                                    .iter()
-                                    .find(|n| n.range.start > safe_start)
-                                    .map(|n| n.range.start),
+                            // Preserve goal_column across the empty block, mirroring the
+                            // token handler. An empty block's caret is always at visible
+                            // column 0, so when goal_column is unset we seed it with 0;
+                            // when it is already set (carried in from an earlier block) we
+                            // keep it so the caret lands at that column in the target.
+                            let goal_col = if let Some(nc) = nav_ctx {
+                                if let Some(gc) = (nc.goal_column)() {
+                                    gc
+                                } else {
+                                    let mut gc_sig = nc.goal_column;
+                                    gc_sig.set(Some(0));
+                                    0
+                                }
+                            } else {
+                                0
                             };
-                            if let Some(target_offset) = target {
+                            if let Some(target_node) =
+                                adjacent_editable_node(&augmented, safe_start, direction)
+                            {
+                                let t_start = target_node.range.start.min(raw_nav.len());
+                                let t_end = target_node.range.end.min(raw_nav.len());
+                                let clamped = resolve_visible_column_in_block(
+                                    &target_node,
+                                    &raw_nav,
+                                    t_start,
+                                    t_end,
+                                    goal_col,
+                                );
                                 cctx.cursor_position.set(CursorPosition {
-                                    offset: target_offset,
+                                    offset: clamped,
                                     line: 0,
                                     column: 0,
                                 });
@@ -599,6 +616,11 @@ fn TokenAwareBlockEditor(
                 }
                 if is_single_line_block && (key == "ArrowUp" || key == "ArrowDown") {
                     evt.prevent_default();
+                    // NOTE (#75): the visual-line sub-issues remain unaddressed here — a
+                    // soft-wrapped single raw line is still treated as one visual line
+                    // (`is_single_line_block`), so ArrowUp/Down jumps to the adjacent
+                    // block instead of the adjacent visual row. That requires DOM line
+                    // geometry and is out of scope for this fix.
                     if let Some(mut cctx) = cursor_ctx {
                         let parsed = (ctx.parsed_doc)();
                         let direction = if key == "ArrowUp" {
@@ -608,6 +630,12 @@ fn TokenAwareBlockEditor(
                         };
                         let block_id_vert = block_id_nav.clone();
                         let raw_vert = ctx.raw_value();
+                        // Navigate over the AUGMENTED AST so synthetic blank-line gap
+                        // paragraphs (from `inject_gap_paragraphs`) are reachable by
+                        // arrow keys — matching the empty-block handler. Navigating the
+                        // raw `parsed.ast` would skip them, jumping over visible blank
+                        // lines that are clickable but otherwise unreachable.
+                        let augmented = inject_gap_paragraphs(&parsed.ast, &raw_vert);
                         spawn(async move {
                             let visible_now = {
                                 let js = interop::caret_adapter()
@@ -630,7 +658,7 @@ fn TokenAwareBlockEditor(
                                 visible_now
                             };
                             if let Some(target_node) = adjacent_editable_node(
-                                &parsed.ast,
+                                &augmented,
                                 safe_start,
                                 direction,
                             ) {
@@ -2077,11 +2105,6 @@ pub(crate) fn snap_cursor_to_block(ast: &[OwnedAstNode], cursor: usize) -> usize
     }
 }
 
-/// Perform a block split: insert `\n\n` at the cursor position within a block.
-///
-/// Shared between `TokenAwareBlockEditor` (Enter key) and `ActiveBlockEditor`
-/// (textarea split message). Updates raw content, triggers reparse, and sets
-/// cursor to the start of the new paragraph.
 /// Pure logic for splitting a block at `split_byte` (offset within the block).
 ///
 /// Returns `(rebuilt_global, new_left_len, cursor_offset)`. Inserts a paragraph
@@ -2111,6 +2134,9 @@ fn compute_block_split(
     (rebuilt, left.len(), start + split_at + sep.len())
 }
 
+/// Apply a block split via [`compute_block_split`]: rewrite the raw content,
+/// trigger a reparse, update the block length signal, and move the cursor to the
+/// start of the new paragraph.
 fn perform_block_split(
     ctx: MarkdownContext,
     cursor_ctx: Option<CursorContext>,
@@ -2170,13 +2196,12 @@ fn perform_block_join(ctx: MarkdownContext, cursor_ctx: Option<CursorContext>, b
 #[cfg(test)]
 mod tests {
     use super::{
-        BeforeInputMeta, NavDirection, VisibleEdit, adjacent_editable_offset,
-        block_has_inline_markup, clamp_to_char_boundary, compute_block_split,
-        compute_post_visible_caret, cursor_within_inline_markup, direct_delete_from_beforeinput,
-        inject_gap_paragraphs,
-        is_latest_revision, next_visible_char_utf16, normalize_cursor_visible_for_edit,
-        previous_visible_char_utf16, select_best_input_projection, snap_cursor_to_block,
-        uses_token_aware_surface,
+        BeforeInputMeta, NavDirection, VisibleEdit, adjacent_editable_node,
+        adjacent_editable_offset, block_has_inline_markup, clamp_to_char_boundary,
+        compute_block_split, compute_post_visible_caret, cursor_within_inline_markup,
+        direct_delete_from_beforeinput, inject_gap_paragraphs, is_latest_revision,
+        next_visible_char_utf16, normalize_cursor_visible_for_edit, previous_visible_char_utf16,
+        select_best_input_projection, snap_cursor_to_block, uses_token_aware_surface,
     };
     use crate::inline_tokens::{InlineSegment, SegmentKind, TokenizedBlock};
     use crate::types::{NodeType, OwnedAstNode};
@@ -2259,6 +2284,94 @@ mod tests {
 
         let prev = adjacent_editable_offset(&ast, 7, 12, NavDirection::Prev);
         assert_eq!(prev, 4);
+    }
+
+    // ── adjacent_editable_node over the AUGMENTED ast (#75) ──────────
+    //
+    // The vertical-arrow handlers navigate over `inject_gap_paragraphs(...)`
+    // so the synthetic blank-line gap paragraphs are reachable. These guard
+    // that `adjacent_editable_node` lands on the synthetic gap node rather than
+    // skipping over it to the next real block.
+
+    fn augmented_two_paragraphs() -> Vec<OwnedAstNode> {
+        // "Hello\n\nWorld\n": pulldown-cmark absorbs one trailing '\n' into the
+        // first block (0..6), leaving a 1-byte gap (the second '\n') at 6..7.
+        let ast = vec![
+            OwnedAstNode {
+                node_type: NodeType::Paragraph,
+                range: 0..6, // "Hello\n"
+                children: vec![text_node(0, 5, "Hello")],
+            },
+            OwnedAstNode {
+                node_type: NodeType::Paragraph,
+                range: 7..13, // "World\n"
+                children: vec![text_node(7, 12, "World")],
+            },
+        ];
+        let augmented = inject_gap_paragraphs(&ast, "Hello\n\nWorld\n");
+        // Sanity: [Hello, <gap 6..7>, World].
+        assert_eq!(augmented.len(), 3);
+        assert_eq!(augmented[1].range, 6..7);
+        assert!(augmented[1].children.is_empty());
+        augmented
+    }
+
+    #[test]
+    fn adjacent_node_next_reaches_synthetic_gap_paragraph() {
+        let augmented = augmented_two_paragraphs();
+        // From the first block (start 0), Next must land on the synthetic gap
+        // paragraph at 6..7, NOT skip ahead to "World" at 7.
+        let target = adjacent_editable_node(&augmented, 0, NavDirection::Next)
+            .expect("a next editable node exists");
+        assert_eq!(target.range, 6..7);
+        assert!(target.children.is_empty());
+    }
+
+    #[test]
+    fn adjacent_node_prev_reaches_synthetic_gap_paragraph() {
+        let augmented = augmented_two_paragraphs();
+        // From "World" (start 7), Prev must land on the synthetic gap paragraph
+        // at 6..7, NOT skip back to "Hello" at 0.
+        let target = adjacent_editable_node(&augmented, 7, NavDirection::Prev)
+            .expect("a prev editable node exists");
+        assert_eq!(target.range, 6..7);
+        assert!(target.children.is_empty());
+    }
+
+    #[test]
+    fn adjacent_node_skips_gap_when_navigating_off_synthetic_node() {
+        // Standing ON the synthetic gap node (start 6): Next reaches "World" (7),
+        // Prev reaches "Hello" (0). Confirms the gap is a first-class waypoint that
+        // arrow keys stop on exactly once in each direction.
+        let augmented = augmented_two_paragraphs();
+        let next = adjacent_editable_node(&augmented, 6, NavDirection::Next)
+            .expect("next exists from gap");
+        assert_eq!(next.range, 7..13);
+        let prev = adjacent_editable_node(&augmented, 6, NavDirection::Prev)
+            .expect("prev exists from gap");
+        assert_eq!(prev.range, 0..6);
+    }
+
+    #[test]
+    fn adjacent_node_non_augmented_ast_skips_gap() {
+        // Contrast: over the RAW (non-augmented) ast there is no node between the
+        // two paragraphs, so Next from "Hello" jumps straight to "World". This is
+        // the pre-#75 behaviour the augmented-ast fix corrects.
+        let ast = vec![
+            OwnedAstNode {
+                node_type: NodeType::Paragraph,
+                range: 0..6,
+                children: vec![text_node(0, 5, "Hello")],
+            },
+            OwnedAstNode {
+                node_type: NodeType::Paragraph,
+                range: 7..13,
+                children: vec![text_node(7, 12, "World")],
+            },
+        ];
+        let target =
+            adjacent_editable_node(&ast, 0, NavDirection::Next).expect("a next editable node");
+        assert_eq!(target.range, 7..13);
     }
 
     #[test]

--- a/crates/markdown/src/inline_editor.rs
+++ b/crates/markdown/src/inline_editor.rs
@@ -327,7 +327,6 @@ fn TokenAwareBlockEditor(
     let current_len = use_signal(|| safe_end.saturating_sub(safe_start));
     let mut is_composing = use_signal(|| false);
     let mut input_revision = use_signal(|| 0u64);
-    let applied_revision = use_signal(|| 0u64);
     let mut caret_generation = use_signal(|| 0u64);
     let restore_generation = use_signal(|| 0u64);
     let mut pending_restore_raw = use_signal(|| None::<PendingCaretRestore>);
@@ -732,7 +731,6 @@ fn TokenAwareBlockEditor(
                     handler,
                     next_revision,
                     input_revision,
-                    applied_revision,
                     pending_restore_raw,
                 );
             },
@@ -767,7 +765,6 @@ fn TokenAwareBlockEditor(
                     handler,
                     next_revision,
                     input_revision,
-                    applied_revision,
                     pending_restore_raw,
                 );
             },
@@ -1019,7 +1016,6 @@ fn spawn_token_editor_sync(
     handler: Option<EventHandler<ActiveBlockInputEvent>>,
     captured_revision: u64,
     latest_revision: Signal<u64>,
-    mut applied_revision: Signal<u64>,
     mut pending_restore: Signal<Option<PendingCaretRestore>>,
 ) {
     spawn(async move {
@@ -1084,7 +1080,6 @@ fn spawn_token_editor_sync(
             len_sig.set(rebuilt_local.len());
             ctx.handle_value_change(rebuilt_global.clone());
             ctx.trigger_parse.call(());
-            applied_revision.set(captured_revision);
 
             let raw_cursor_local = raw_del_start.min(last_caret_offset(&(0..rebuilt_local.len())));
 
@@ -1211,7 +1206,6 @@ fn spawn_token_editor_sync(
         len_sig.set(rebuilt_local.len());
         ctx.handle_value_change(rebuilt_global.clone());
         ctx.trigger_parse.call(());
-        applied_revision.set(captured_revision);
 
         let raw_cursor_local = cursor_after_visible_edit(
             selected_model,
@@ -2097,6 +2091,35 @@ pub(crate) fn snap_cursor_to_block(ast: &[OwnedAstNode], cursor: usize) -> usize
 /// Shared between `TokenAwareBlockEditor` (Enter key) and `ActiveBlockEditor`
 /// (textarea split message). Updates raw content, triggers reparse, and sets
 /// cursor to the start of the new paragraph.
+/// Pure logic for splitting a block at `split_byte` (offset within the block).
+///
+/// Returns `(rebuilt_global, new_left_len, cursor_offset)`. Inserts a paragraph
+/// break at the split point. When splitting at the very END of a block that is
+/// already followed by a blank-line gap (`after` begins with `\n`), inserts a
+/// single `\n` instead of `\n\n` — otherwise the block's own trailing newline plus
+/// the inserted pair stack into 3-4 consecutive newlines and the gap grows on every
+/// Enter-at-block-end.
+fn compute_block_split(
+    global: &str,
+    start: usize,
+    end: usize,
+    split_byte: usize,
+) -> (String, usize, usize) {
+    let before = &global[..start];
+    let block = &global[start..end];
+    let after = &global[end..];
+    let split_at = clamp_to_char_boundary(block, split_byte.min(block.len()));
+    let left = &block[..split_at];
+    let right = &block[split_at..];
+    let sep: &str = if right.is_empty() && after.starts_with('\n') {
+        "\n"
+    } else {
+        "\n\n"
+    };
+    let rebuilt = format!("{before}{left}{sep}{right}{after}");
+    (rebuilt, left.len(), start + split_at + sep.len())
+}
+
 fn perform_block_split(
     ctx: MarkdownContext,
     cursor_ctx: Option<CursorContext>,
@@ -2108,19 +2131,14 @@ fn perform_block_split(
     let start = safe_start.min(current_global.len());
     let old_len = *len_sig.read();
     let end = (start + old_len).min(current_global.len());
-    let before = &current_global[..start];
-    let block = &current_global[start..end];
-    let after = &current_global[end..];
-    let split_at = split_byte.min(block.len());
-    let left = &block[..split_at];
-    let right = &block[split_at..];
-    let rebuilt = format!("{before}{left}\n\n{right}{after}");
+    let (rebuilt, left_len, cursor_offset) =
+        compute_block_split(&current_global, start, end, split_byte);
     ctx.handle_value_change(rebuilt);
     ctx.trigger_parse.call(());
-    len_sig.set(left.len());
+    len_sig.set(left_len);
     if let Some(mut cctx) = cursor_ctx {
         cctx.cursor_position.set(CursorPosition {
-            offset: start + split_at + 2,
+            offset: cursor_offset,
             line: 0,
             column: 0,
         });
@@ -2162,8 +2180,9 @@ fn perform_block_join(ctx: MarkdownContext, cursor_ctx: Option<CursorContext>, b
 mod tests {
     use super::{
         BeforeInputMeta, NavDirection, VisibleEdit, adjacent_editable_offset,
-        block_has_inline_markup, clamp_to_char_boundary, compute_post_visible_caret,
-        cursor_within_inline_markup, direct_delete_from_beforeinput, inject_gap_paragraphs,
+        block_has_inline_markup, clamp_to_char_boundary, compute_block_split,
+        compute_post_visible_caret, cursor_within_inline_markup, direct_delete_from_beforeinput,
+        inject_gap_paragraphs,
         is_latest_revision, next_visible_char_utf16, normalize_cursor_visible_for_edit,
         previous_visible_char_utf16, select_best_input_projection, snap_cursor_to_block,
         uses_token_aware_surface,
@@ -2447,6 +2466,35 @@ mod tests {
         assert_eq!(result[0].range, 0..2);
         assert_eq!(result[1].range, 5..6); // synthetic at the real '\n', not 2..3
         assert_eq!(result[2].range, 6..7);
+    }
+
+    #[test]
+    fn compute_block_split_midblock_inserts_paragraph_break() {
+        // "HelloWorld" split at 5 → two paragraphs, cursor at start of "World".
+        let (rebuilt, left_len, cursor) = compute_block_split("HelloWorld", 0, 10, 5);
+        assert_eq!(rebuilt, "Hello\n\nWorld");
+        assert_eq!(left_len, 5);
+        assert_eq!(cursor, 7);
+    }
+
+    #[test]
+    fn compute_block_split_at_end_before_gap_avoids_triple_newline() {
+        // "Hello\n\nWorld": block "Hello" is bytes 0..5 (trimmed), so `after`
+        // ("\n\nWorld") already starts with the block's trailing newline. Splitting
+        // at the end must insert ONE newline, not "\n\n" (which would stack to 4).
+        let (rebuilt, left_len, cursor) = compute_block_split("Hello\n\nWorld", 0, 5, 5);
+        assert_eq!(rebuilt, "Hello\n\n\nWorld");
+        assert!(!rebuilt.contains("\n\n\n\n"));
+        assert_eq!(left_len, 5);
+        assert_eq!(cursor, 6); // lands in the new blank paragraph
+    }
+
+    #[test]
+    fn compute_block_split_at_end_of_last_block_uses_full_break() {
+        // Last block, no following gap → "\n\n" so a new empty paragraph is created.
+        let (rebuilt, _left, cursor) = compute_block_split("Hello", 0, 5, 5);
+        assert_eq!(rebuilt, "Hello\n\n");
+        assert_eq!(cursor, 7);
     }
 
     #[test]

--- a/crates/markdown/src/inline_editor.rs
+++ b/crates/markdown/src/inline_editor.rs
@@ -14,8 +14,10 @@ use crate::viewport::ViewportNode;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PendingCaretRestore {
+    /// Absolute raw byte offset; remapped to a visible offset through the *current*
+    /// model when the restore runs, so the caret stays in lockstep with marker
+    /// visibility after a reparse.
     Raw(usize),
-    Visible(usize),
     /// Visible UTF-16 offsets for a non-collapsed selection.
     Selection {
         start: usize,
@@ -68,6 +70,7 @@ pub fn InlineEditor(
     let parsed = (ctx.parsed_doc)();
     let raw = ctx.raw_value();
     let augmented_ast = inject_gap_paragraphs(&parsed.ast, &raw);
+    let augmented_len = augmented_ast.len();
 
     // Cursor snapping: if cursor is in a gap between blocks, snap to nearest
     use_effect(move || {
@@ -108,8 +111,15 @@ pub fn InlineEditor(
             div {
                 class: "nox-md-viewport",
                 "data-md-viewport": "true",
-                for node in augmented_ast.into_iter() {
+                for (block_idx , node) in augmented_ast.iter().enumerate() {
                     InlineBlockNode {
+                        // Key by block start offset so Dioxus matches blocks by identity,
+                        // not list position. Without this, inserting/removing a synthetic
+                        // gap paragraph shifts positions and grafts the active block's live
+                        // contenteditable (caret/IME) and its `current_len` signal onto a
+                        // different block — corrupting edits.
+                        key: "{node.range.start}",
+                        is_last: block_idx + 1 == augmented_len,
                         node: node.clone(),
                         cursor_offset: cursor_offset,
                         on_active_block_input: on_active_block_input,
@@ -136,10 +146,15 @@ fn is_editable_block(node: &OwnedAstNode) -> bool {
 fn InlineBlockNode(
     node: OwnedAstNode,
     cursor_offset: usize,
+    #[props(default = false)] is_last: bool,
     on_active_block_input: Option<EventHandler<ActiveBlockInputEvent>>,
     on_key_intercept: Option<Callback<String, bool>>,
 ) -> Element {
-    let is_active = cursor_offset >= node.range.start && cursor_offset < node.range.end;
+    // Half-open interval, except the final block is inclusive at its upper bound so
+    // the caret can rest at the very end of a document with no trailing newline
+    // (otherwise no editor renders there and the caret snaps back one char).
+    let is_active = cursor_offset >= node.range.start
+        && (cursor_offset < node.range.end || (is_last && cursor_offset == node.range.end));
     if !is_active {
         return rsx! { InactiveBlockView { node: node } };
     }
@@ -506,10 +521,6 @@ fn TokenAwareBlockEditor(
                     .saturating_sub(safe_start)
                     .min(last_caret_offset(&(0..model_for_effect.raw_text.len())));
                 let v = raw_offset_to_visible_utf16(&model_for_effect, local_raw);
-                interop::caret_adapter().set_contenteditable_selection_js(&block_id_effect, v)
-            }
-            PendingCaretRestore::Visible(visible) => {
-                let v = visible.min(utf16_len(&model_for_effect.visible_text));
                 interop::caret_adapter().set_contenteditable_selection_js(&block_id_effect, v)
             }
             PendingCaretRestore::Selection { start, end } => interop::caret_adapter()
@@ -1053,6 +1064,12 @@ fn spawn_token_editor_sync(
             && let Some((raw_del_start, raw_del_end, new_cursor_vis)) =
                 direct_delete_from_beforeinput(meta, &model, &block_raw_current)
         {
+            // Floor to char boundaries: the delete range is derived from the
+            // render-time model, which may disagree with the live `block_raw_current`
+            // around multi-byte characters.
+            let raw_del_start = clamp_to_char_boundary(&block_raw_current, raw_del_start);
+            let raw_del_end =
+                clamp_to_char_boundary(&block_raw_current, raw_del_end).max(raw_del_start);
             let rebuilt_local = format!(
                 "{}{}",
                 &block_raw_current[..raw_del_start],
@@ -1078,7 +1095,14 @@ fn spawn_token_editor_sync(
                     column: 0,
                 });
             }
-            pending_restore.set(Some(PendingCaretRestore::Visible(new_cursor_vis)));
+            // Restore by RAW offset, not a visible offset captured in the pre-edit
+            // model's coordinate space: after reparse the marker visibility can
+            // change, so a stale visible offset drifts the caret (and compounds on
+            // the next keystroke). The restore effect remaps this through the fresh
+            // model. `new_cursor_vis` is still reported to the handler below.
+            pending_restore.set(Some(PendingCaretRestore::Raw(
+                start.saturating_add(raw_cursor_local),
+            )));
 
             if let Some(handler) = handler {
                 let mut fresh_node = node_local.clone();
@@ -1160,10 +1184,18 @@ fn spawn_token_editor_sync(
             cursor_visible_utf16,
             utf16_len(&new_visible),
         );
-        let old_raw_start = visible_utf16_to_raw_offset(selected_model, edit.old_start_utf16)
-            .min(block_raw_current.len());
-        let old_raw_end = visible_utf16_to_raw_offset(selected_model, edit.old_end_utf16)
-            .min(block_raw_current.len());
+        // Floor to char boundaries: `selected_model` may be the render-time model,
+        // whose `raw_text` can disagree with the live `block_raw_current` around
+        // multi-byte characters; slicing at a non-boundary would panic.
+        let old_raw_start = clamp_to_char_boundary(
+            &block_raw_current,
+            visible_utf16_to_raw_offset(selected_model, edit.old_start_utf16),
+        );
+        let old_raw_end = clamp_to_char_boundary(
+            &block_raw_current,
+            visible_utf16_to_raw_offset(selected_model, edit.old_end_utf16),
+        )
+        .max(old_raw_start);
         let rebuilt_local = format!(
             "{}{}{}",
             &block_raw_current[..old_raw_start],
@@ -1197,7 +1229,13 @@ fn spawn_token_editor_sync(
                 column: 0,
             });
         }
-        pending_restore.set(Some(PendingCaretRestore::Visible(effective_cursor_visible)));
+        // Restore by RAW offset (remapped through the fresh model by the restore
+        // effect) rather than a visible offset in the pre-edit model's space, which
+        // drifts when marker visibility changes on reparse. `effective_cursor_visible`
+        // is still reported to the handler below.
+        pending_restore.set(Some(PendingCaretRestore::Raw(
+            start.saturating_add(raw_cursor_local),
+        )));
 
         if let Some(handler) = handler {
             let mut fresh_node = node_local.clone();
@@ -1637,6 +1675,20 @@ fn utf16_len(s: &str) -> usize {
     s.chars().map(char::len_utf16).sum()
 }
 
+/// Clamp a byte offset to a valid UTF-8 char boundary of `s` (flooring).
+///
+/// Offsets mapped through a possibly-stale `TokenizedBlock` model can land in the
+/// middle of a multi-byte char when the model's `raw_text` differs from the string
+/// actually being sliced; slicing there would panic. This floors to the nearest
+/// preceding char boundary so the splice is always valid.
+fn clamp_to_char_boundary(s: &str, idx: usize) -> usize {
+    let mut idx = idx.min(s.len());
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
 fn is_latest_revision(captured: u64, latest: u64) -> bool {
     captured == latest
 }
@@ -1966,35 +2018,37 @@ pub(crate) fn inject_gap_paragraphs(ast: &[OwnedAstNode], raw: &str) -> Vec<Owne
         let gap_start = prev_end;
         let gap_end = node.range.start;
         if gap_start < gap_end {
-            let gap_bytes = &raw[gap_start..gap_end];
-            // Every `\n` in the gap becomes a synthetic empty paragraph.
-            // Standard `\n\n` separator → 1 synthetic node (visible blank line).
-            let newline_count = gap_bytes.bytes().filter(|&b| b == b'\n').count();
-            for i in 0..newline_count {
-                let byte_pos = gap_start + i;
-                result.push(OwnedAstNode {
-                    node_type: NodeType::Paragraph,
-                    range: byte_pos..byte_pos + 1,
-                    children: vec![],
-                });
+            // Every `\n` in the gap becomes a synthetic empty paragraph, placed at the
+            // newline's ACTUAL byte offset. Using the filtered-newline index as the
+            // position is wrong whenever the gap also contains non-newline bytes (e.g.
+            // a blank line with trailing spaces), producing a synthetic node over the
+            // wrong byte. Standard `\n\n` separator → 1 synthetic node (visible blank line).
+            for (offset, &b) in raw.as_bytes()[gap_start..gap_end].iter().enumerate() {
+                if b == b'\n' {
+                    let byte_pos = gap_start + offset;
+                    result.push(OwnedAstNode {
+                        node_type: NodeType::Paragraph,
+                        range: byte_pos..byte_pos + 1,
+                        children: vec![],
+                    });
+                }
             }
         }
         result.push(node.clone());
         prev_end = node.range.end;
     }
 
-    // Trailing gap: after the last block
+    // Trailing gap: after the last block — same actual-byte-offset rule.
     if prev_end < raw.len() {
-        let trailing = &raw[prev_end..];
-        let newline_count = trailing.bytes().filter(|&b| b == b'\n').count();
-        // Every `\n` in the trailing gap becomes a synthetic node
-        for i in 0..newline_count {
-            let byte_pos = prev_end + i;
-            result.push(OwnedAstNode {
-                node_type: NodeType::Paragraph,
-                range: byte_pos..byte_pos + 1,
-                children: vec![],
-            });
+        for (offset, &b) in raw.as_bytes()[prev_end..].iter().enumerate() {
+            if b == b'\n' {
+                let byte_pos = prev_end + offset;
+                result.push(OwnedAstNode {
+                    node_type: NodeType::Paragraph,
+                    range: byte_pos..byte_pos + 1,
+                    children: vec![],
+                });
+            }
         }
     }
 
@@ -2024,7 +2078,15 @@ pub(crate) fn snap_cursor_to_block(ast: &[OwnedAstNode], cursor: usize) -> usize
     // Past all blocks — snap to last block's range
     let last = &ast[ast.len() - 1];
     if last.range.end > last.range.start {
-        last.range.end.saturating_sub(1)
+        // The caret exactly at the last block's end is a valid end-of-document
+        // position (the block editor trims any trailing newline itself); keep it so
+        // it stays usable. Only step back off a trailing newline when the cursor is
+        // genuinely beyond the document.
+        if cursor == last.range.end {
+            cursor
+        } else {
+            last.range.end.saturating_sub(1)
+        }
     } else {
         last.range.start
     }
@@ -2100,10 +2162,11 @@ fn perform_block_join(ctx: MarkdownContext, cursor_ctx: Option<CursorContext>, b
 mod tests {
     use super::{
         BeforeInputMeta, NavDirection, VisibleEdit, adjacent_editable_offset,
-        block_has_inline_markup, compute_post_visible_caret, cursor_within_inline_markup,
-        direct_delete_from_beforeinput, inject_gap_paragraphs, is_latest_revision,
-        next_visible_char_utf16, normalize_cursor_visible_for_edit, previous_visible_char_utf16,
-        select_best_input_projection, snap_cursor_to_block, uses_token_aware_surface,
+        block_has_inline_markup, clamp_to_char_boundary, compute_post_visible_caret,
+        cursor_within_inline_markup, direct_delete_from_beforeinput, inject_gap_paragraphs,
+        is_latest_revision, next_visible_char_utf16, normalize_cursor_visible_for_edit,
+        previous_visible_char_utf16, select_best_input_projection, snap_cursor_to_block,
+        uses_token_aware_surface,
     };
     use crate::inline_tokens::{InlineSegment, SegmentKind, TokenizedBlock};
     use crate::types::{NodeType, OwnedAstNode};
@@ -2361,6 +2424,45 @@ mod tests {
     }
 
     #[test]
+    fn inject_gap_paragraphs_places_node_at_actual_newline_byte() {
+        // Gap with a blank line carrying trailing spaces: "A\n   \nB".
+        // The single gap newline sits at byte 5 (after "A\n   "), NOT at the
+        // filtered-newline index 2. The synthetic node must land on byte 5.
+        let ast = vec![
+            OwnedAstNode {
+                node_type: NodeType::Paragraph,
+                range: 0..2, // "A\n"
+                children: vec![text_node(0, 1, "A")],
+            },
+            OwnedAstNode {
+                node_type: NodeType::Paragraph,
+                range: 6..7, // "B"
+                children: vec![text_node(6, 7, "B")],
+            },
+        ];
+        let raw = "A\n   \nB";
+        let result = inject_gap_paragraphs(&ast, raw);
+        // Gap is raw[2..6] = "   \n" → one newline at absolute byte 5.
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].range, 0..2);
+        assert_eq!(result[1].range, 5..6); // synthetic at the real '\n', not 2..3
+        assert_eq!(result[2].range, 6..7);
+    }
+
+    #[test]
+    fn clamp_to_char_boundary_floors_into_multibyte_char() {
+        let s = "a😀b"; // 'a'=1 byte, '😀'=4 bytes (1..5), 'b'=1 byte (5..6)
+        assert_eq!(clamp_to_char_boundary(s, 0), 0);
+        assert_eq!(clamp_to_char_boundary(s, 1), 1); // boundary before emoji
+        assert_eq!(clamp_to_char_boundary(s, 2), 1); // mid-emoji → floor to 1
+        assert_eq!(clamp_to_char_boundary(s, 3), 1);
+        assert_eq!(clamp_to_char_boundary(s, 4), 1);
+        assert_eq!(clamp_to_char_boundary(s, 5), 5); // boundary after emoji
+        assert_eq!(clamp_to_char_boundary(s, 6), 6); // end
+        assert_eq!(clamp_to_char_boundary(s, 99), 6); // past end → len
+    }
+
+    #[test]
     fn inject_gap_paragraphs_multiple_extra_blank_lines() {
         // "Hello\n\n\n\nWorld\n" — gap is 3 bytes ("\n\n\n"),
         // 3 newlines in gap → 3 synthetic nodes (loop 0..3)
@@ -2470,6 +2572,10 @@ mod tests {
         ];
         // Cursor at 20 is past all blocks, snaps to last block end - 1
         assert_eq!(snap_cursor_to_block(&ast, 20), 13);
+        // Cursor EXACTLY at the last block's end is a valid end-of-document caret
+        // (e.g. a document with no trailing newline) and must be preserved, not
+        // pulled back to end-1.
+        assert_eq!(snap_cursor_to_block(&ast, 14), 14);
     }
 
     #[test]

--- a/crates/markdown/src/inline_editor.rs
+++ b/crates/markdown/src/inline_editor.rs
@@ -1019,6 +1019,12 @@ fn spawn_token_editor_sync(
     mut pending_restore: Signal<Option<PendingCaretRestore>>,
 ) {
     spawn(async move {
+        // Early bail: if a newer oninput already superseded us, stop before issuing
+        // any DOM reads. The beforeinput metadata read below is non-destructive, so a
+        // stale sync that slips past here cannot starve the latest sync of its meta.
+        if *latest_revision.read() != captured_revision {
+            return;
+        }
         let new_visible = {
             let js = interop::caret_adapter().read_contenteditable_text_js(&block_id);
             let mut eval = interop::start_eval(&js);
@@ -1427,7 +1433,6 @@ fn ActiveBlockEditor(
             },
             onmounted: move |_| {
                 let js = interop::caret_adapter().mount_active_textarea_js(&block_id_mount, target_cursor);
-                let mut len_sig = current_len;
                 if let Some(mut cctx) = cursor_ctx {
                     spawn(async move {
                         let mut eval = interop::start_eval(&js);
@@ -1466,23 +1471,9 @@ fn ActiveBlockEditor(
                                 perform_block_join(ctx, Some(cctx), safe_start);
                                 continue;
                             }
-                            if let Some(rest) = msg.strip_prefix("split:")
-                                && let Ok(split_utf16) = rest.parse::<usize>()
-                            {
-                                let current_global = ctx.raw_value();
-                                let start = safe_start.min(current_global.len());
-                                let old_len = *len_sig.read();
-                                let end = (start + old_len).min(current_global.len());
-                                let block = &current_global[start..end];
-                                let split_byte = utf16_to_byte_index(block, split_utf16).unwrap_or(block.len());
-                                perform_block_split(
-                                    ctx,
-                                    Some(cctx),
-                                    safe_start,
-                                    &mut len_sig,
-                                    split_byte,
-                                );
-                            }
+                            // Enter is not intercepted for code blocks (see
+                            // mount_active_textarea_js): it inserts a literal newline,
+                            // so no "split:" message is dispatched here.
                         }
                     });
                 } else {

--- a/crates/markdown/src/inline_tokens.rs
+++ b/crates/markdown/src/inline_tokens.rs
@@ -376,13 +376,24 @@ fn block_prefix_range(node: &OwnedAstNode, raw: &str) -> Option<Range<usize>> {
 }
 
 fn heading_prefix_len(raw: &str) -> usize {
+    // Prefix = optional indentation + the `#` marker run + one separating space run.
+    // It must NOT swallow content that merely starts with `#` (e.g. `# #tag` is an
+    // h1 whose content is `#tag`, so the prefix is just `# `).
+    let bytes = raw.as_bytes();
     let mut idx = 0usize;
-    for ch in raw.chars() {
-        if ch == '#' || ch == ' ' {
-            idx += ch.len_utf8();
-        } else {
-            break;
-        }
+    while idx < bytes.len() && bytes[idx] == b' ' {
+        idx += 1;
+    }
+    let mut saw_hash = false;
+    while idx < bytes.len() && bytes[idx] == b'#' {
+        idx += 1;
+        saw_hash = true;
+    }
+    if !saw_hash {
+        return 0;
+    }
+    while idx < bytes.len() && bytes[idx] == b' ' {
+        idx += 1;
     }
     idx
 }
@@ -400,23 +411,33 @@ fn blockquote_prefix_len(raw: &str) -> usize {
 }
 
 fn list_prefix_len(raw: &str) -> usize {
+    // Prefix = optional indentation + a bullet (`-`/`*`/`+`) or an ordered marker
+    // (digits + `.`/`)`) + one required separating space. It must NOT swallow
+    // content such as a task checkbox `[x]` or a bracketed link — `- [x] done`
+    // has prefix `- ` and content `[x] done`, not `- [`.
     let bytes = raw.as_bytes();
     let mut idx = 0usize;
-    while idx < bytes.len() {
-        let b = bytes[idx];
-        let is_prefix = b == b'-'
-            || b == b'*'
-            || b == b'+'
-            || b == b'['
-            || b == b']'
-            || b == b' '
-            || b == b'.'
-            || (b as char).is_ascii_digit();
-        if is_prefix {
+    while idx < bytes.len() && bytes[idx] == b' ' {
+        idx += 1;
+    }
+    if idx < bytes.len() && matches!(bytes[idx], b'-' | b'*' | b'+') {
+        idx += 1;
+    } else {
+        let digits_start = idx;
+        while idx < bytes.len() && bytes[idx].is_ascii_digit() {
             idx += 1;
-        } else {
-            break;
         }
+        if idx == digits_start || idx >= bytes.len() || !matches!(bytes[idx], b'.' | b')') {
+            return 0;
+        }
+        idx += 1; // the `.` or `)`
+    }
+    let after_marker = idx;
+    while idx < bytes.len() && bytes[idx] == b' ' {
+        idx += 1;
+    }
+    if idx == after_marker {
+        return 0; // a list marker requires a following space
     }
     idx
 }
@@ -467,6 +488,47 @@ mod tests {
         let raw = "- hello world";
         let markers = collect_marker_tokens(&node, raw, 0);
         assert!(!markers.is_empty());
+        assert_eq!(markers[0].kind, MarkerKind::BlockPrefix);
+        assert_eq!(markers[0].raw_range, 0..2);
+    }
+
+    #[test]
+    fn list_prefix_does_not_swallow_task_checkbox() {
+        // `- [x] done` — the prefix is `- `, NOT `- [` (the checkbox is content).
+        let node = OwnedAstNode {
+            node_type: NodeType::Item,
+            range: 0..10,
+            children: vec![text_node(2, 10, "[x] done")],
+        };
+        let raw = "- [x] done";
+        let markers = collect_marker_tokens(&node, raw, 0);
+        assert_eq!(markers[0].kind, MarkerKind::BlockPrefix);
+        assert_eq!(markers[0].raw_range, 0..2);
+    }
+
+    #[test]
+    fn ordered_list_prefix_is_marker_plus_space() {
+        let node = OwnedAstNode {
+            node_type: NodeType::Item,
+            range: 0..9,
+            children: vec![text_node(3, 9, "item")],
+        };
+        let raw = "12. item";
+        let markers = collect_marker_tokens(&node, raw, 0);
+        assert_eq!(markers[0].kind, MarkerKind::BlockPrefix);
+        assert_eq!(markers[0].raw_range, 0..4); // "12. "
+    }
+
+    #[test]
+    fn heading_prefix_does_not_swallow_content_hash() {
+        // `# #tag` — h1 whose content is `#tag`; the prefix is `# ` (len 2).
+        let node = OwnedAstNode {
+            node_type: NodeType::Heading(1),
+            range: 0..6,
+            children: vec![text_node(2, 6, "#tag")],
+        };
+        let raw = "# #tag";
+        let markers = collect_marker_tokens(&node, raw, 0);
         assert_eq!(markers[0].kind, MarkerKind::BlockPrefix);
         assert_eq!(markers[0].raw_range, 0..2);
     }

--- a/crates/markdown/src/interop.rs
+++ b/crates/markdown/src/interop.rs
@@ -184,9 +184,16 @@ impl CaretAdapter for WebviewCaretAdapter {
     }
 
     fn read_contenteditable_text_js(&self, block_id: &str) -> String {
+        // Use `textContent`, not `innerText`: every caret/selection offset in this
+        // module is measured with `range.toString().length` / `node.nodeValue.length`,
+        // which share `textContent` semantics. `innerText` is layout-aware (collapses
+        // whitespace, emits "\n" for <br>/block boundaries, forces reflow) and would
+        // put the text read in a different coordinate space than the offsets, corrupting
+        // edit reconstruction. Hidden markers are excluded from the rendered DOM, so
+        // `textContent` equals the model's `visible_text`.
         format!(
             "var el = document.getElementById('{block_id}');\
-             if(el) dioxus.send(el.innerText ?? '');\
+             if(el) dioxus.send(el.textContent ?? '');\
              else dioxus.send('');"
         )
     }

--- a/crates/markdown/src/interop.rs
+++ b/crates/markdown/src/interop.rs
@@ -122,12 +122,10 @@ impl CaretAdapter for WebviewCaretAdapter {
                         e.preventDefault();
                         dioxus.send("backjoin");
                     }}
-                }} else if (e.key === 'Enter') {{
-                    if (!e.shiftKey) {{
-                        e.preventDefault();
-                        dioxus.send("split:" + (el.selectionStart ?? 0));
-                    }}
                 }}
+                // Enter is intentionally NOT intercepted: this textarea backs a fenced
+                // code block, where Enter must insert a literal newline within the block
+                // (native textarea behavior), not split it into two paragraphs.
             }});
             el._noxTraversalBound = true;
         }}
@@ -176,9 +174,11 @@ impl CaretAdapter for WebviewCaretAdapter {
         dioxus.send("");
         return;
     }}
-    var meta = root._noxBeforeInputMeta;
-    root._noxBeforeInputMeta = null;
-    dioxus.send(meta);
+    // Non-destructive: do NOT null the slot here. Each `beforeinput` overwrites it,
+    // so the slot always reflects the latest edit; reading it destructively let a
+    // stale (superseded) sync consume the metadata before the surviving latest sync
+    // could read it, which dropped the latest edit onto the lossy diff fallback.
+    dioxus.send(root._noxBeforeInputMeta);
 }})();"#
         )
     }

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -466,13 +466,7 @@ fn render_tag(
             });
             if is_task {
                 let checked_str = match &children.first().unwrap().event {
-                    CustomEvent::Standard(Event::TaskListMarker(checked)) => {
-                        if *checked {
-                            "true"
-                        } else {
-                            "false"
-                        }
-                    }
+                    CustomEvent::Standard(Event::TaskListMarker(checked)) if *checked => "true",
                     _ => "false",
                 };
                 rsx! {

--- a/crates/markdown/src/reveal_engine.rs
+++ b/crates/markdown/src/reveal_engine.rs
@@ -241,13 +241,33 @@ mod tests {
         // `**bold**` envelope 0..8; caret at 8 (just past the closing `**`) is
         // OUTSIDE the token → markers hidden, so Backspace there deletes content.
         let markers = vec![
-            MarkerToken { raw_range: 0..2, token_range: 0..8, kind: MarkerKind::Inline },
-            MarkerToken { raw_range: 6..8, token_range: 0..8, kind: MarkerKind::Inline },
+            MarkerToken {
+                raw_range: 0..2,
+                token_range: 0..8,
+                kind: MarkerKind::Inline,
+            },
+            MarkerToken {
+                raw_range: 6..8,
+                token_range: 0..8,
+                kind: MarkerKind::Inline,
+            },
         ];
-        let at_end = marker_visibility(&markers, RevealContext { caret_raw_offset: 8, selection: None });
+        let at_end = marker_visibility(
+            &markers,
+            RevealContext {
+                caret_raw_offset: 8,
+                selection: None,
+            },
+        );
         assert_eq!(at_end, vec![false, false]);
         // Caret just inside the closing content (offset 6, end of "bold") still reveals.
-        let inside = marker_visibility(&markers, RevealContext { caret_raw_offset: 6, selection: None });
+        let inside = marker_visibility(
+            &markers,
+            RevealContext {
+                caret_raw_offset: 6,
+                selection: None,
+            },
+        );
         assert_eq!(inside, vec![true, true]);
     }
 
@@ -255,12 +275,34 @@ mod tests {
     fn adjacent_tokens_resolve_to_the_one_being_entered() {
         // Token A 0..8 and token B 8..16 share boundary 8. Caret at 8 reveals B, not A.
         let markers = vec![
-            MarkerToken { raw_range: 0..2, token_range: 0..8, kind: MarkerKind::Inline },
-            MarkerToken { raw_range: 6..8, token_range: 0..8, kind: MarkerKind::Inline },
-            MarkerToken { raw_range: 8..10, token_range: 8..16, kind: MarkerKind::Inline },
-            MarkerToken { raw_range: 14..16, token_range: 8..16, kind: MarkerKind::Inline },
+            MarkerToken {
+                raw_range: 0..2,
+                token_range: 0..8,
+                kind: MarkerKind::Inline,
+            },
+            MarkerToken {
+                raw_range: 6..8,
+                token_range: 0..8,
+                kind: MarkerKind::Inline,
+            },
+            MarkerToken {
+                raw_range: 8..10,
+                token_range: 8..16,
+                kind: MarkerKind::Inline,
+            },
+            MarkerToken {
+                raw_range: 14..16,
+                token_range: 8..16,
+                kind: MarkerKind::Inline,
+            },
         ];
-        let vis = marker_visibility(&markers, RevealContext { caret_raw_offset: 8, selection: None });
+        let vis = marker_visibility(
+            &markers,
+            RevealContext {
+                caret_raw_offset: 8,
+                selection: None,
+            },
+        );
         assert_eq!(vis, vec![false, false, true, true]);
     }
 }

--- a/crates/markdown/src/reveal_engine.rs
+++ b/crates/markdown/src/reveal_engine.rs
@@ -90,7 +90,12 @@ fn active_inline_token(markers: &[MarkerToken], ctx: RevealContext) -> Option<Ra
 }
 
 fn in_range(offset: usize, range: &Range<usize>) -> bool {
-    offset >= range.start && offset <= range.end
+    // Half-open at the trailing edge: a caret exactly at `range.end` (just past the
+    // closing marker, e.g. `**bold**|`) is OUTSIDE the token, so its markers stay
+    // hidden and Backspace deletes content, not a literal `*`. The leading edge
+    // stays inclusive (caret just before the opening marker reveals). This also
+    // makes two adjacent tokens sharing a boundary resolve to the one being entered.
+    offset >= range.start && offset < range.end
 }
 
 fn ranges_overlap(a: &Range<usize>, b: &Range<usize>) -> bool {
@@ -229,5 +234,33 @@ mod tests {
             },
         );
         assert_eq!(vis, vec![true, true, false, false]);
+    }
+
+    #[test]
+    fn caret_just_past_closing_marker_hides_it() {
+        // `**bold**` envelope 0..8; caret at 8 (just past the closing `**`) is
+        // OUTSIDE the token → markers hidden, so Backspace there deletes content.
+        let markers = vec![
+            MarkerToken { raw_range: 0..2, token_range: 0..8, kind: MarkerKind::Inline },
+            MarkerToken { raw_range: 6..8, token_range: 0..8, kind: MarkerKind::Inline },
+        ];
+        let at_end = marker_visibility(&markers, RevealContext { caret_raw_offset: 8, selection: None });
+        assert_eq!(at_end, vec![false, false]);
+        // Caret just inside the closing content (offset 6, end of "bold") still reveals.
+        let inside = marker_visibility(&markers, RevealContext { caret_raw_offset: 6, selection: None });
+        assert_eq!(inside, vec![true, true]);
+    }
+
+    #[test]
+    fn adjacent_tokens_resolve_to_the_one_being_entered() {
+        // Token A 0..8 and token B 8..16 share boundary 8. Caret at 8 reveals B, not A.
+        let markers = vec![
+            MarkerToken { raw_range: 0..2, token_range: 0..8, kind: MarkerKind::Inline },
+            MarkerToken { raw_range: 6..8, token_range: 0..8, kind: MarkerKind::Inline },
+            MarkerToken { raw_range: 8..10, token_range: 8..16, kind: MarkerKind::Inline },
+            MarkerToken { raw_range: 14..16, token_range: 8..16, kind: MarkerKind::Inline },
+        ];
+        let vis = marker_visibility(&markers, RevealContext { caret_raw_offset: 8, selection: None });
+        assert_eq!(vis, vec![false, false, true, true]);
     }
 }

--- a/crates/noxpad/Cargo.toml
+++ b/crates/noxpad/Cargo.toml
@@ -10,7 +10,6 @@ dioxus-nox-shell  = { workspace = true }
 dioxus-nox-markdown = { workspace = true, features = ["syntax-highlighting"] }
 dioxus-nox-cmdk   = { workspace = true, features = ["web"] }
 dioxus-nox-suggest = { workspace = true }
-dioxus-nox-tag-input = { workspace = true }
 dioxus-nox-dnd    = { workspace = true }
 dioxus-nox-preview = { workspace = true }
 dioxus-nox-gestures = { workspace = true }

--- a/crates/select/src/components.rs
+++ b/crates/select/src/components.rs
@@ -217,17 +217,13 @@ pub fn Trigger(
                 }
                 ctx.highlight_last();
             }
-            Key::Escape => {
-                if was_open {
-                    event.prevent_default();
-                    ctx.set_open(false);
-                }
+            Key::Escape if was_open => {
+                event.prevent_default();
+                ctx.set_open(false);
             }
-            Key::Tab => {
-                // Close on Tab (do NOT prevent default — let focus move)
-                if was_open {
-                    ctx.confirm_highlighted();
-                }
+            // Close on Tab (do NOT prevent default — let focus move)
+            Key::Tab if was_open => {
+                ctx.confirm_highlighted();
             }
             // Type-ahead for printable characters
             Key::Character(ref c) if c != " " => {
@@ -428,29 +424,21 @@ pub fn Input(
                     ctx.highlight_next();
                 }
             }
-            Key::ArrowUp => {
-                if was_open {
-                    event.prevent_default();
-                    ctx.highlight_prev();
-                }
+            Key::ArrowUp if was_open => {
+                event.prevent_default();
+                ctx.highlight_prev();
             }
-            Key::Enter => {
-                if was_open && ctx.highlighted.read().is_some() {
-                    event.prevent_default();
-                    ctx.confirm_highlighted();
-                }
+            Key::Enter if was_open && ctx.highlighted.read().is_some() => {
+                event.prevent_default();
+                ctx.confirm_highlighted();
             }
-            Key::Escape => {
-                if was_open {
-                    event.prevent_default();
-                    ctx.set_open(false);
-                }
+            Key::Escape if was_open => {
+                event.prevent_default();
+                ctx.set_open(false);
             }
             // Home/End: let the input handle cursor movement (no preventDefault)
-            Key::Tab => {
-                if was_open {
-                    ctx.set_open(false);
-                }
+            Key::Tab if was_open => {
+                ctx.set_open(false);
             }
             _ => {}
         }

--- a/crates/suggest/src/components.rs
+++ b/crates/suggest/src/components.rs
@@ -167,8 +167,9 @@ pub fn Trigger(
     // effect with zero subscriptions; when the prop later flips `None -> Some`
     // (e.g. editor mode switch Inline -> Source -> Inline), Dioxus 0.7's effect
     // scheduler has nothing to invalidate and the effect never re-runs, so
-    // trigger detection silently dies until reload. See crate CLAUDE.md
-    // "Known Issues: external_input effect subscription lost after mode switch".
+    // trigger detection silently dies until reload. Bumping this counter on every
+    // `None <-> Some` transition (see below) gives the scheduler a subscription to
+    // invalidate, forcing the effect to re-run and rebind to the new prop.
     let detect_gen: Signal<u64> = use_signal(|| 0);
 
     // Previous `external_input.is_some()` value, tracked via a plain Cell so the

--- a/crates/suggest/src/components.rs
+++ b/crates/suggest/src/components.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::rc::Rc;
 
 use dioxus::prelude::*;
@@ -160,9 +161,48 @@ pub fn Trigger(
 ) -> Element {
     let ctx = use_context::<TriggerContext>();
 
+    // Generation counter that the detection effect ALWAYS reads first, so it
+    // retains at least one signal subscription even while `external_input` is
+    // `None`. Without this, the `None`-branch early-return below would leave the
+    // effect with zero subscriptions; when the prop later flips `None -> Some`
+    // (e.g. editor mode switch Inline -> Source -> Inline), Dioxus 0.7's effect
+    // scheduler has nothing to invalidate and the effect never re-runs, so
+    // trigger detection silently dies until reload. See crate CLAUDE.md
+    // "Known Issues: external_input effect subscription lost after mode switch".
+    let detect_gen: Signal<u64> = use_signal(|| 0);
+
+    // Previous `external_input.is_some()` value, tracked via a plain Cell so the
+    // transition check in the render body adds no extra reactive subscription
+    // (workspace gotcha: "Signal transition detection -> Rc<Cell<_>> via use_hook").
+    let prev_external_some: Rc<Cell<bool>> =
+        use_hook(|| Rc::new(Cell::new(external_input.is_some())));
+
+    // The component body re-renders whenever the `external_input` prop changes
+    // (props are PartialEq-compared). On a `None <-> Some` flip we bump
+    // `detect_gen` to re-run the detection effect. The bump is deferred to a
+    // spawned task rather than written here directly: a bare signal `.set()` in
+    // the render body is the AP-3 anti-pattern. Since the body never *reads*
+    // `detect_gen`, the bump only invalidates the detection effect's reactive
+    // context, never this component's — so it cannot re-render the body and
+    // cannot re-enter this transition check. The Cell is updated synchronously,
+    // so even a redundant re-render would not bump again. This provably cannot
+    // loop.
+    let current_external_some = external_input.is_some();
+    if current_external_some != prev_external_some.get() {
+        prev_external_some.set(current_external_some);
+        let mut g = detect_gen;
+        spawn(async move {
+            let next = g.peek().wrapping_add(1);
+            g.set(next);
+        });
+    }
+
     // Reactive trigger detection from external signal (contenteditable / InlineEditor).
     // Hook is always called unconditionally; Option guard is inside.
     use_effect(move || {
+        // Subscribe to `detect_gen` BEFORE the `None` early-return so the effect
+        // always has at least one subscription to invalidate (Dioxus 0.7 gotcha).
+        let _gen = detect_gen();
         let Some(ext) = external_input else { return };
         let (text, cursor_utf16) = (ext)();
         let configs = ctx.trigger_configs.read().clone();
@@ -284,11 +324,9 @@ pub fn Trigger(
                         e.prevent_default();
                         ctx.select_prev();
                     }
-                    "Enter" => {
-                        if ctx.highlighted_index.read().is_some() {
-                            e.prevent_default();
-                            ctx.confirm_selection();
-                        }
+                    "Enter" if ctx.highlighted_index.read().is_some() => {
+                        e.prevent_default();
+                        ctx.confirm_selection();
                     }
                     "Escape" | "Tab" => {
                         ctx.close();

--- a/crates/suggest/src/types.rs
+++ b/crates/suggest/src/types.rs
@@ -161,13 +161,9 @@ impl TriggerContext {
                 self.select_prev();
                 true
             }
-            "Enter" => {
-                if self.highlighted_index.read().is_some() {
-                    self.confirm_selection();
-                    true
-                } else {
-                    false
-                }
+            "Enter" if self.highlighted_index.read().is_some() => {
+                self.confirm_selection();
+                true
             }
             "Escape" | "Tab" => {
                 self.close();

--- a/crates/tag-input/src/hook.rs
+++ b/crates/tag-input/src/hook.rs
@@ -989,13 +989,11 @@ impl<T: TagLike> TagInputState<T> {
         // ── Readonly mode: only allow pill entry and escape ─────────────
         if readonly {
             match key {
-                Key::ArrowLeft => {
-                    if self.search_query.read().is_empty() {
-                        let len = self.selected_tags.read().len();
-                        if len > 0 {
-                            event.prevent_default();
-                            self.active_pill.set(Some(len - 1));
-                        }
+                Key::ArrowLeft if self.search_query.read().is_empty() => {
+                    let len = self.selected_tags.read().len();
+                    if len > 0 {
+                        event.prevent_default();
+                        self.active_pill.set(Some(len - 1));
                     }
                 }
                 Key::Escape => {
@@ -1009,14 +1007,12 @@ impl<T: TagLike> TagInputState<T> {
 
         // ── Input mode (normal) ─────────────────────────────────────────
         match key {
-            Key::ArrowLeft => {
-                // Enter pill mode from the right when query is empty
-                if self.search_query.read().is_empty() {
-                    let len = self.selected_tags.read().len();
-                    if len > 0 {
-                        event.prevent_default();
-                        self.active_pill.set(Some(len - 1));
-                    }
+            // Enter pill mode from the right when query is empty
+            Key::ArrowLeft if self.search_query.read().is_empty() => {
+                let len = self.selected_tags.read().len();
+                if len > 0 {
+                    event.prevent_default();
+                    self.active_pill.set(Some(len - 1));
                 }
             }
             Key::Enter => {
@@ -1040,14 +1036,12 @@ impl<T: TagLike> TagInputState<T> {
                     }
                 }
             }
-            Key::Backspace => {
-                // On empty input, select last *unlocked* pill instead of immediately deleting
-                if self.search_query.read().is_empty() {
-                    let tags = self.selected_tags.read();
-                    if let Some(pos) = tags.iter().rposition(|t| !t.is_locked()) {
-                        drop(tags);
-                        self.active_pill.set(Some(pos));
-                    }
+            // On empty input, select last *unlocked* pill instead of immediately deleting
+            Key::Backspace if self.search_query.read().is_empty() => {
+                let tags = self.selected_tags.read();
+                if let Some(pos) = tags.iter().rposition(|t| !t.is_locked()) {
+                    drop(tags);
+                    self.active_pill.set(Some(pos));
                 }
             }
             Key::Escape => {


### PR DESCRIPTION
## Summary

Resolves the inline live-preview markdown editor defects surfaced by an xhigh `/code-review` (issues #70–#85). Implemented and adversarially audited via multi-agent workflows, with the **headline bug live-validated in a real browser**.

## Verification
- **303** markdown unit tests pass; **40** suggest tests pass (regression tests added for every pure-logic fix).
- wasm clippy (markdown + suggest) clean; `cargo check -p noxpad --target wasm32-unknown-unknown` and `cargo check --workspace` clean.
- **Live Playwright** (headless Chromium driving `dx serve`): **3/3 PASS** —
  - **#74 headline:** typed `some **bold** text`, caret after the closing `**`, held Backspace ×6 → asterisks shrank **4→2 monotonically**, no `***` growth, confirmed by reading the source back. The corruption does **not** reproduce.
  - **#76:** Enter inside a fenced code block inserts a single newline (no paragraph split).
  - Typing + `# Heading` sanity, zero console errors.
- Two adversarial audit rounds (9 agents each): all **SOUND**; the only CONCERNs were a verified non-issue (#70, intended/tested behavior) and documentation-only (now corrected).

## Closes
Fixes #70, #71, #72, #73, #74, #76, #77, #79, #80, #81, #82, #83, #84, #85

## What changed
| Issue | Fix |
|---|---|
| #74 | Headline asterisk-duplication — closed by the structural cluster below; **live-validated**. |
| #71/#77 | contenteditable text read via `textContent` (matches the offset space; kills the empty-block `<br>` phantom newline). |
| #82 | reveal-engine inline-token envelope half-open at the trailing edge — caret just past `**bold**` keeps markers hidden, so Backspace deletes content; adjacent tokens resolve to the entered one. |
| #81 | `beforeinput` metadata read non-destructive + early staleness guard — the latest sync always reads its own fresh meta, keeping the precise direct-delete path engaged under rapid input. |
| #85 | caret restored by raw offset remapped through the fresh model (no post-reparse drift). |
| #72 | block-list `key:` so synthetic-gap shifts don't graft the active contenteditable / `current_len` onto another block. |
| #73 | char-boundary clamp on edit-reconstruction slices → no multibyte panic. |
| #79 | last block's caret inclusive at end + `snap` keeps the end-of-doc caret. |
| #83 | synthetic gap paragraphs placed at the actual newline byte. |
| #84 | heading/list prefix detectors stop at content (`# #tag`, `- [x]`). |
| #70 | `compute_block_split` inserts one `\n` (not `\n\n`) at a block end already followed by a gap. |
| #76 | code-block Enter inserts a literal newline (removed the dead `split:` path). |
| #80 | suggest `Trigger` re-subscribes its detection effect across an editor mode round-trip (generation signal + `use_hook` transition cell, no AP-3, provably loop-free). |
| #78 | removed dead `applied_revision` signal + unused `tag-input` dependency. |
| — | drive-by `parser.rs` / `suggest` clippy gate fixes; audit doc-comment corrections. |

## Still open
- **#75** — the two tractable nav fixes landed (single-line nav reaches blank-line gaps via the augmented AST; empty-block nav preserves `goal_column`). The **visual-line** sub-parts (multi-line block caret escape; soft-wrap row traversal) need DOM line geometry and remain.
- **#78** — the dead `applied_revision` signal and the unused `tag-input` dependency are removed; the `utf16_to_byte_index` 4× dedup and the candidate-model-heuristic altitude refactor remain (the `sidebar` duplicate-breakpoint item did not exist in the current tree).
- **#87** (new, filed from the audit) — `deleteWordBackward` (Ctrl+Backspace) near a marker leaves dangling markers. Distinct from #74 (no growth, different input type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
