### PR TITLE
fix(calendar): classify multi-month pane cells against the pane month

### DIFF
--- a/crates/calendar/src/components.rs
+++ b/crates/calendar/src/components.rs
@@ -695,7 +695,10 @@ fn Cell(date: Date) -> Element {
     let is_disabled = base.is_date_disabled(date);
     let is_unavailable = base.is_date_unavailable(date);
     let is_focused = focus.is_focused(date);
-    let rel_month = math::relative_month(date, view.month(), base.enabled_range());
+    // Classify against this pane's month (base view + MonthView offset), not the
+    // base month — otherwise every in-month cell of a non-base pane reads as
+    // outside-month. `view` stays on the base view for the focus fallback below.
+    let rel_month = math::pane_relative_month(view, current_offset(), date, base.enabled_range());
     let is_outside = !rel_month.is_current();
 
     let (is_selected, range_pos) = match selection {

--- a/crates/calendar/src/math.rs
+++ b/crates/calendar/src/math.rs
@@ -113,6 +113,24 @@ pub fn relative_month(
     }
 }
 
+/// Classify a cell's relative month against the month of its own pane.
+///
+/// In a multi-month layout each pane is offset `offset` months ahead of the
+/// base view date. The pane's grid is built from that offset-adjusted month,
+/// so cells must be classified against the same month — not the base month —
+/// or every in-month cell of a non-base pane would read as outside-month.
+pub fn pane_relative_month(
+    base_view: Date,
+    offset: u8,
+    date: Date,
+    enabled_range: DateRange,
+) -> RelativeMonth {
+    let pane_month = nth_month_next(base_view, offset)
+        .unwrap_or(base_view)
+        .month();
+    relative_month(date, pane_month, enabled_range)
+}
+
 // ── Grid generation ─────────────────────────────────────────────────
 
 /// Generate a flat list of dates for a calendar month grid.

--- a/crates/calendar/src/tests.rs
+++ b/crates/calendar/src/tests.rs
@@ -432,6 +432,72 @@ fn relative_month_data_attr() {
     assert_eq!(RelativeMonth::Next.as_data_attr(), "next");
 }
 
+// ── pane_relative_month (multi-month pane classification) ───────────
+
+#[test]
+fn pane_relative_month_offset_zero_matches_base() {
+    // Offset 0 is single-month mode: classification must equal classifying
+    // against the base view's own month, byte-for-byte.
+    let range = DateRange::new(date!(2026 - 01 - 01), date!(2026 - 12 - 31));
+    let base = date!(2026 - 04 - 01);
+    for day in 1..=30u8 {
+        let d = date!(2026 - 04 - 01).replace_day(day).unwrap();
+        assert_eq!(
+            pane_relative_month(base, 0, d, range),
+            relative_month(d, base.month(), range),
+            "offset-0 classification diverged from base month for {d}"
+        );
+    }
+}
+
+#[test]
+fn pane_relative_month_offset_one_in_month_is_current() {
+    // Regression for #90: base view March 2026, second pane (offset 1) shows
+    // April. An April date is in-month for that pane and must classify as
+    // Current — the pre-fix path classified it against March and returned Next,
+    // flagging the entire second pane as outside-month.
+    let range = DateRange::new(date!(2026 - 01 - 01), date!(2026 - 12 - 31));
+    let base = date!(2026 - 03 - 01);
+    assert_eq!(
+        pane_relative_month(base, 1, date!(2026 - 04 - 15), range),
+        RelativeMonth::Current
+    );
+    // And the buggy base-month path would have (wrongly) said Next — proving
+    // this test depends on the corrected pane month, not the base month.
+    assert_eq!(
+        relative_month(date!(2026 - 04 - 15), base.month(), range),
+        RelativeMonth::Next
+    );
+}
+
+#[test]
+fn pane_relative_month_offset_one_leading_and_trailing() {
+    // For the offset-1 (April) pane: a trailing March date is Previous, a
+    // leading May date is Next, relative to the pane's own month.
+    let range = DateRange::new(date!(2026 - 01 - 01), date!(2026 - 12 - 31));
+    let base = date!(2026 - 03 - 01);
+    assert_eq!(
+        pane_relative_month(base, 1, date!(2026 - 03 - 31), range),
+        RelativeMonth::Previous
+    );
+    assert_eq!(
+        pane_relative_month(base, 1, date!(2026 - 05 - 01), range),
+        RelativeMonth::Next
+    );
+}
+
+#[test]
+fn pane_relative_month_offset_wraps_year() {
+    // Base December 2026, offset 1 → pane is January 2027. A January 2027 date
+    // is in-month for that pane.
+    let range = DateRange::new(date!(2026 - 01 - 01), date!(2027 - 12 - 31));
+    let base = date!(2026 - 12 - 01);
+    assert_eq!(
+        pane_relative_month(base, 1, date!(2027 - 01 - 15), range),
+        RelativeMonth::Current
+    );
+}
+
 // ── navigate_with (disabled-date skip) ──────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Problem

In a multi-month calendar (`month_count >= 2` using `MonthView` panes), every date in a non-base pane was flagged `data-outside-month="true"` with the wrong `data-month`. Consumers that dim outside-month dates ended up greying out the entire second/third pane.

## Cause

`Grid` builds each pane's grid from the offset-adjusted month (`nth_month_next(base, offset)`), but `Cell` classified every date against the *base* view month. For an `offset > 0` pane the cells and their month classification disagreed: an in-month date of the pane (e.g. an April date in the `offset = 1` pane of a March base) compared `date.month()` against March and resolved to `Next`, so `is_outside` was always true.

## Fix

`Cell` now classifies the cell against its own pane's month (base view + `MonthView` offset) via a new pure helper `math::pane_relative_month`. The `tabindex`/focus fallback stays on the base view, so per-pane tab-stop behaviour is unchanged. In single-month mode the pane month equals the base month, so that path is byte-for-byte identical.

## Tests

Added unit tests for `pane_relative_month`:
- offset-0 classification matches the base-month path for every day (single-month parity)
- an in-month date of an `offset = 1` pane classifies as `Current` (the regression), with an explicit assertion that the old base-month path returned `Next`
- leading/trailing dates of an offset pane classify as `Previous`/`Next`
- year-wrapping offset (Dec base, offset 1 → Jan next year)

Verified the offset tests fail when the helper is wired to the base month and pass with the pane month.

Fixes #90