### PR TITLE
chore(ci): pin Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -44,7 +44,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

Pins the Rust toolchain so builds are deterministic across local and CI:

- Adds `rust-toolchain.toml` (`channel = "1.96.0"`, with `clippy`/`rustfmt` components and the `wasm32-unknown-unknown` target).
- Pins the three `dtolnay/rust-toolchain@stable` refs in `.github/workflows/ci.yml` to `@1.96.0`.

## Why

CI previously floated on `@stable`, so the toolchain version was whatever `rustup` resolved at run time. That makes it possible for a future stable release to introduce lints (or other changes) that silently turn `main` red without any code change. Pinning to the version CI already uses (`1.96.0`) keeps `cargo clippy --workspace --all-targets -- -D warnings` reproducible and lets contributors run the exact same toolchain locally via `rust-toolchain.toml`.

The nightly `Rustfmt` job is intentionally left on `@nightly` (it relies on unstable rustfmt options).

## Verification

CI runs the full gauntlet (Rustfmt, Clippy, Tests, WASM Build) on this PR under the pinned toolchain.