### PR TITLE
feat(shell): add ShellContext::close_sidebar

### DIFF
--- a/crates/shell/src/context.rs
+++ b/crates/shell/src/context.rs
@@ -61,6 +61,16 @@ impl ShellContext {
         }
     }
 
+    /// Closes the mobile overlay sidebar.
+    ///
+    /// Setting `sidebar_mobile_open` to `false` is harmless on desktop, where
+    /// the mobile open-state signal is not consulted. Mirrors [`close_modal`]
+    /// and [`close_search`].
+    pub fn close_sidebar(&self) {
+        let mut mob = self.sidebar_mobile_open;
+        mob.set(false);
+    }
+
     /// Returns the `data-shell-sidebar-state` attribute value for the root element.
     ///
     /// | Context | Value |


### PR DESCRIPTION
## Summary

Adds `ShellContext::close_sidebar()`, which closes the mobile overlay sidebar by setting `sidebar_mobile_open` to `false`.

It mirrors the existing `close_modal()` / `close_search()` methods and complements `toggle_sidebar()`, giving consumers an explicit close — e.g. dismissing the drawer after the user navigates — instead of reaching into the raw `sidebar_mobile_open` signal. Setting it `false` is harmless on desktop, where the mobile open-state signal isn't consulted.

## Verification

- `cargo clippy -p dioxus-nox-shell --all-targets -- -D warnings` — clean
- `cargo test -p dioxus-nox-shell` — 36 pass

(The `ShellContext` mutation methods aren't unit-tested in this crate — they require a live Dioxus runtime to construct the signals, same as `close_modal`/`toggle_sidebar` — so this follows existing coverage.)