### PR TITLE
feat(noxpad): mobile sidebar drawer with swipe-to-delete

### DIFF
--- a/crates/noxpad/src/main.rs
+++ b/crates/noxpad/src/main.rs
@@ -26,7 +26,7 @@ use std::sync::LazyLock;
 use dioxus::prelude::*;
 use dioxus_nox_dnd::{FEEDBACK_STYLES, FUNCTIONAL_STYLES};
 use dioxus_nox_markdown::prelude::{Mode, generate_theme_css};
-use dioxus_nox_shell::AppShell;
+use dioxus_nox_shell::{AppShell, MobileSidebarBackdrop};
 
 use crate::css::CSS;
 use crate::editor::NoteEditor;
@@ -72,6 +72,7 @@ fn App() -> Element {
             } else {
                 div { style: "padding:32px; color:#444", "Select a note to begin editing" }
             }
+            MobileSidebarBackdrop {}
         }
     }
 }

--- a/crates/noxpad/src/noxpad.css
+++ b/crates/noxpad/src/noxpad.css
@@ -10,6 +10,9 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 [data-shell-columns="1"] { grid-template-columns: 1fr; grid-template-areas: "main" "footer"; }
 [data-shell-sidebar] { grid-area: sidebar; border-right: 1px solid #2a2a2a;
     overflow-y: auto; background: #111; }
+/* Keep [data-shell-content] free of transform/filter/will-change: any of those
+   would make it the containing block for the position:fixed mobile sidebar
+   backdrop (MobileSidebarBackdrop) and clip the scrim to the content box. */
 [data-shell-content] { grid-area: main; display: flex; flex-direction: column;
     overflow: hidden; }
 [data-shell-preview] { grid-area: preview; border-left: 1px solid #2a2a2a;
@@ -44,6 +47,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 .note-item-title { font-weight: 500; }
 .note-item-tags { font-size: 11px; color: #666; margin-top: 1px; }
 .empty-folder { padding: 8px; color: #555; font-size: 12px; }
+
+/* Hide swipe actions until the row is being dragged or held open */
+[data-swipe-phase="idle"] [data-swipe-actions] { display: none; }
+.swipe-action-delete { background: var(--danger, #e53935); color: #fff; border: none; padding: 0 16px; cursor: pointer; }
 
 /* Editor */
 .note-editor { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
@@ -156,6 +163,35 @@ mark { background: none; color: #7c6af7; font-weight: 600; }
 
 @media (max-width: 639px) {
     [data-shell] { grid-template-columns: 1fr; grid-template-areas: "main" "footer"; }
-    [data-shell-sidebar] { display: none; }
+    [data-shell-sidebar]:not([data-shell-sidebar-mobile]) { display: none; }
     [data-shell-preview] { display: none; }
+}
+
+/* Mobile sidebar drawer */
+/* NOTE: the 639px mobile breakpoint here must stay in lockstep with the shell's
+   compact threshold (AppShell default use_shell_breakpoint compact_below = 640.0,
+   i.e. width < 640px). Changing one without the other desyncs the drawer from
+   the swipe gate by 1px. */
+[data-shell-sidebar-mobile] {
+    position: fixed; top: 0; left: 0; bottom: 0;
+    width: min(280px, 80vw);
+    background: #111; border-right: 1px solid #2a2a2a;
+    overflow-y: auto; z-index: 200;
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+}
+[data-shell-sidebar-mobile][data-shell-sidebar-state="open"] { transform: translateX(0); }
+[data-shell-backdrop] {
+    position: fixed; inset: 0; z-index: 150;
+    background: rgba(0,0,0,0.5);
+}
+
+/* Hamburger toggle — only visible on compact viewports */
+.mobile-sidebar-toggle {
+    display: none;
+    background: transparent; border: none; color: inherit;
+    font-size: 18px; cursor: pointer; padding: 0 8px;
+}
+@media (max-width: 639px) {
+    .mobile-sidebar-toggle { display: inline-block; }
 }

--- a/crates/noxpad/src/panels.rs
+++ b/crates/noxpad/src/panels.rs
@@ -2,6 +2,7 @@
 
 use crate::models::Note;
 use dioxus::prelude::*;
+use dioxus_nox_shell::ShellContext;
 
 #[component]
 pub(crate) fn PreviewPane(notes: Signal<Vec<Note>>, active_idx: Signal<Option<usize>>) -> Element {
@@ -39,7 +40,17 @@ pub(crate) fn StatusBar(notes: Signal<Vec<Note>>, active_idx: Signal<Option<usiz
         Some((words, tags))
     });
 
+    let shell_ctx = try_use_context::<ShellContext>();
+
     rsx! {
+        if let Some(ctx) = shell_ctx {
+            button {
+                class: "mobile-sidebar-toggle",
+                "aria-label": "Toggle sidebar",
+                onclick: move |_| ctx.toggle_sidebar(),
+                "☰"
+            }
+        }
         if let Some((words, tags)) = (stats)() {
             span { "{words} words" }
             span { "{tags} tags" }

--- a/crates/noxpad/src/sidebar.rs
+++ b/crates/noxpad/src/sidebar.rs
@@ -9,6 +9,7 @@ use dioxus_nox_dnd::{
     SortableItem,
 };
 use dioxus_nox_gestures::{SwipeConfig, swipe_actions};
+use dioxus_nox_shell::use_shell_context;
 
 #[component]
 pub(crate) fn NoteSidebar(
@@ -17,6 +18,11 @@ pub(crate) fn NoteSidebar(
     active_idx: Signal<Option<usize>>,
     tabs: Signal<Vec<usize>>,
 ) -> Element {
+    let shell_ctx = use_shell_context();
+    // Single source of truth for "compact viewport": the shell's own breakpoint
+    // (same 640/1024 thresholds AppShell uses by default), so the swipe gate and
+    // the drawer-close logic can never disagree.
+    let is_touch = shell_ctx.is_mobile();
     let folders_snapshot = folders.read().clone();
     let notes_snapshot = notes.read().clone();
     let folder_drag_ids: Vec<DragId> = folders_snapshot
@@ -132,21 +138,8 @@ pub(crate) fn NoteSidebar(
                                                                         drag_type: Some(DragType::new(NOTE_DRAG_TYPE)),
                                                                         handle: Some("[data-drag-handle]".to_string()),
 
-                                                                        swipe_actions::Root {
-                                                                            config: SwipeConfig { action_width_px: 72.0, ..Default::default() },
-                                                                            on_commit: {
-                                                                                let folder_id = folder_id.clone();
-                                                                                move |_| {
-                                                                                    let mut folder_state = folders.write();
-                                                                                    if let Some(f) = folder_state.iter_mut().find(|f| f.id == folder_id) {
-                                                                                        f.note_indices.retain(|&i| i != note_idx);
-                                                                                    }
-                                                                                    let mut tab_state = tabs.write();
-                                                                                    let new_active = close_tab(&mut tab_state, (active_idx)(), note_idx);
-                                                                                    active_idx.set(new_active);
-                                                                                }
-                                                                            },
-                                                                            swipe_actions::Content {
+                                                                        {
+                                                                            let note_row = rsx! {
                                                                                 div {
                                                                                     class: "note-item",
                                                                                     "data-active": if is_active { "true" } else { "false" },
@@ -154,6 +147,9 @@ pub(crate) fn NoteSidebar(
                                                                                         active_idx.set(Some(note_idx));
                                                                                         let mut tab_state = tabs.write();
                                                                                         ensure_tab_open(&mut tab_state, note_idx);
+                                                                                        if shell_ctx.is_mobile() {
+                                                                                            shell_ctx.close_sidebar();
+                                                                                        }
                                                                                     },
                                                                                     span { "data-drag-handle": "", class: "drag-handle", "⠿" }
                                                                                     div { class: "note-item-title", "{title}" }
@@ -161,13 +157,32 @@ pub(crate) fn NoteSidebar(
                                                                                         div { class: "note-item-tags", "{tags_preview}" }
                                                                                     }
                                                                                 }
-                                                                            }
-                                                                            swipe_actions::Actions {
-                                                                                button {
-                                                                                    class: "swipe-action-delete",
-                                                                                    style: "background: var(--danger, #e53935); color: white; border: none; padding: 0 16px; cursor: pointer;",
-                                                                                    "Delete"
+                                                                            };
+                                                                            if is_touch {
+                                                                                let folder_id = folder_id.clone();
+                                                                                rsx! {
+                                                                                    swipe_actions::Root {
+                                                                                        config: SwipeConfig { action_width_px: 72.0, ..Default::default() },
+                                                                                        on_commit: move |_| {
+                                                                                            let mut folder_state = folders.write();
+                                                                                            if let Some(f) = folder_state.iter_mut().find(|f| f.id == folder_id) {
+                                                                                                f.note_indices.retain(|&i| i != note_idx);
+                                                                                            }
+                                                                                            let mut tab_state = tabs.write();
+                                                                                            let new_active = close_tab(&mut tab_state, (active_idx)(), note_idx);
+                                                                                            active_idx.set(new_active);
+                                                                                        },
+                                                                                        swipe_actions::Content { {note_row} }
+                                                                                        swipe_actions::Actions {
+                                                                                            button {
+                                                                                                class: "swipe-action-delete",
+                                                                                                "Delete"
+                                                                                            }
+                                                                                        }
+                                                                                    }
                                                                                 }
+                                                                            } else {
+                                                                                note_row
                                                                             }
                                                                         }
                                                                     }


### PR DESCRIPTION
## Summary

Adds a responsive mobile sidebar to the noxpad demo, exercising the shell's mobile-drawer and the gestures swipe-actions on compact viewports.

- **Mobile drawer**: wires `AppShell`'s mobile sidebar + renders `MobileSidebarBackdrop`; on compact viewports the sidebar slides in over the content with a scrim (CSS keys off `data-shell-sidebar-mobile` / `data-shell-sidebar-state`).
- **Hamburger toggle**: a compact-only button in the status bar that calls `toggle_sidebar()`. Acquired via `try_use_context`, so it simply doesn't render if there's no shell context (no panic).
- **Tap-to-close**: selecting a note closes the drawer via `close_sidebar()`.
- **Swipe-to-delete, mobile-only**: note rows are wrapped in `swipe_actions` only when the shell reports a compact viewport (`is_mobile`), so **desktop never renders the swipe Delete action** — it's not a desktop gesture. On mobile the Delete stays hidden until the row is swiped (`[data-swipe-phase="idle"]` rule).

The swipe gate and the drawer-close logic both read the single shell breakpoint (`is_mobile`) so they can't disagree.

## Verification

- `cargo check -p noxpad --target wasm32-unknown-unknown` — clean
- `cargo clippy -p noxpad --target wasm32-unknown-unknown -- -D warnings` — clean

Depends on `ShellContext::close_sidebar` (landed in #95).